### PR TITLE
Line status

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,6 +1,9 @@
 class RecordsController < ApplicationController
   before_action :set_ramen_shop
-  before_action :set_ramen_shop_record, only: %i[measure edit update]
+  before_action :set_ramen_shop_record, only: %i[show measure edit update]
+
+  def show
+  end
 
   def new
     @ramen_shop_record = @ramen_shop.records.build
@@ -33,7 +36,7 @@ class RecordsController < ApplicationController
     @ramen_shop_record.calculate_wait_time!
 
     if @ramen_shop_record.save
-      redirect_to ramen_shop_path(@ramen_shop_record.ramen_shop), notice: 'ちゃくどんレコードを登録しました'
+      redirect_to ramen_shop_record_path(@ramen_shop, @ramen_shop_record), notice: 'ちゃくどんレコードを登録しました'
     else
       render :new
     end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -3,17 +3,14 @@ class RecordsController < ApplicationController
     @ramen_shop = RamenShop.find(params[:ramen_shop_id])
     @ramen_shop_record = @ramen_shop.records.build
     @ramen_shop_record.line_statuses.build
-    # @ramen_shop_record = @ramen_shop.records.build(
-    #   started_at: Time.current
-    # )
   end
 
   def create
     ramen_shop = RamenShop.find(params[:ramen_shop_id])
-    record = Record.new(record_param)
+    ramen_shop_record = Record.new(record_param)
 
-    if record.save
-      redirect_to ramen_shop_record_measure_path(ramen_shop, record)
+    if ramen_shop_record.save
+      redirect_to ramen_shop_record_measure_path(ramen_shop, ramen_shop_record)
     else
       render :new, status: :unprocessable_entity
     end
@@ -21,20 +18,27 @@ class RecordsController < ApplicationController
 
   def measure
     @ramen_shop = RamenShop.find(params[:ramen_shop_id])
-    @record = Record.find(params[:record_id])
+    @ramen_shop_record = Record.find(params[:id])
 
-    if @record.update(started_at: Time.current)
+    if @ramen_shop_record.update(started_at: Time.current)
       flash.notice = "セツゾクしました"
     else
       render :new, status: :unprocessable_entity
     end
   end
 
-  def update
-    @record = Record.new(record_param).calculate_wait_time!
+  def edit
+    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
+    @ramen_shop_record = Record.find(params[:id])
+  end
 
-    if @record.save
-      redirect_to ramen_shop_path(@record.ramen_shop), notice: 'Record was successfully created.'
+  def update
+    ramen_shop_record = Record.find(params[:id])
+    ramen_shop_record.assign_attributes(record_param)
+    ramen_shop_record.calculate_wait_time!
+
+    if ramen_shop_record.save
+      redirect_to ramen_shop_path(ramen_shop_record.ramen_shop), notice: 'ちゃくどんレコードを登録しました'
     else
       render :new
     end
@@ -43,6 +47,6 @@ class RecordsController < ApplicationController
   private
 
   def record_param
-    params.require(:record).permit(:ramen_shop_id, :started_at, line_statuses_attributes: [:line_number, :line_type])
+    params.require(:record).permit(:ramen_shop_id, :started_at, :ended_at, line_statuses_attributes: [:line_number, :line_type])
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,12 +1,36 @@
 class RecordsController < ApplicationController
   def new
     @ramen_shop = RamenShop.find(params[:ramen_shop_id])
-    @ramen_shop_record = @ramen_shop.records.build(
-      started_at: Time.current
-    )
+    @ramen_shop_record = @ramen_shop.records.build
+    @ramen_shop_record.line_statuses.build
+    # @ramen_shop_record = @ramen_shop.records.build(
+    #   started_at: Time.current
+    # )
   end
 
   def create
+    ramen_shop = RamenShop.find(params[:ramen_shop_id])
+    record = Record.new(record_param)
+
+    if record.save
+      redirect_to ramen_shop_record_measure_path(ramen_shop, record)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def measure
+    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
+    @record = Record.find(params[:record_id])
+
+    if @record.update(started_at: Time.current)
+      flash.notice = "セツゾクしました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
     @record = Record.new(record_param).calculate_wait_time!
 
     if @record.save
@@ -19,6 +43,6 @@ class RecordsController < ApplicationController
   private
 
   def record_param
-    params.require(:record).permit(:ramen_shop_id, :started_at, :queue_number)
+    params.require(:record).permit(:ramen_shop_id, :started_at, line_statuses_attributes: [:line_number, :line_type])
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,25 +1,23 @@
 class RecordsController < ApplicationController
+  before_action :set_ramen_shop
+  before_action :set_ramen_shop_record, only: %i[measure edit update]
+
   def new
-    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
     @ramen_shop_record = @ramen_shop.records.build
     @ramen_shop_record.line_statuses.build
   end
 
   def create
-    ramen_shop = RamenShop.find(params[:ramen_shop_id])
     ramen_shop_record = Record.new(record_param)
 
     if ramen_shop_record.save
-      redirect_to ramen_shop_record_measure_path(ramen_shop, ramen_shop_record)
+      redirect_to measure_ramen_shop_record_path(@ramen_shop, ramen_shop_record)
     else
       render :new, status: :unprocessable_entity
     end
   end
 
   def measure
-    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
-    @ramen_shop_record = Record.find(params[:id])
-
     if @ramen_shop_record.update(started_at: Time.current)
       flash.notice = "セツゾクしました"
     else
@@ -28,23 +26,28 @@ class RecordsController < ApplicationController
   end
 
   def edit
-    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
-    @ramen_shop_record = Record.find(params[:id])
   end
 
   def update
-    ramen_shop_record = Record.find(params[:id])
-    ramen_shop_record.assign_attributes(record_param)
-    ramen_shop_record.calculate_wait_time!
+    @ramen_shop_record.assign_attributes(record_param)
+    @ramen_shop_record.calculate_wait_time!
 
-    if ramen_shop_record.save
-      redirect_to ramen_shop_path(ramen_shop_record.ramen_shop), notice: 'ちゃくどんレコードを登録しました'
+    if @ramen_shop_record.save
+      redirect_to ramen_shop_path(@ramen_shop_record.ramen_shop), notice: 'ちゃくどんレコードを登録しました'
     else
       render :new
     end
   end
 
   private
+
+  def set_ramen_shop
+    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
+  end
+
+  def set_ramen_shop_record
+    @ramen_shop_record = Record.find(params[:id])
+  end
 
   def record_param
     params.require(:record).permit(:ramen_shop_id, :started_at, :ended_at, line_statuses_attributes: [:line_number, :line_type])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def format_datetime(datetime)
+    wdays = %w(日 月 火 水 木 金 土)
+    datetime.strftime("%Y/%m/%d(#{wdays[datetime.wday]}) %H:%M")
+  end
+
+  def format_wait_time(wait_time)
+    hours, remainder = wait_time.divmod(3600)
+    minutes, seconds = remainder.divmod(60)
+    format("%02d:%02d:%02d", hours, minutes, seconds)
+  end
 end

--- a/app/helpers/ramen_shops_helper.rb
+++ b/app/helpers/ramen_shops_helper.rb
@@ -1,7 +1,2 @@
 module RamenShopsHelper
-  def format_duration(duration)
-    hours, remainder = duration.divmod(3600)
-    minutes, seconds = remainder.divmod(60)
-    format("%02d:%02d:%02d", hours, minutes, seconds)
-  end
 end

--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -7,64 +7,23 @@ window.initMap = () => {
   class Popup extends google.maps.OverlayView {
     position;
     containerDiv;
-    constructor(position, content, url) {
+    constructor(position, shopName, url) {
       super();
       this.position = position;
 
       // Create the anchor tag with content and add the popup-bubble class
       const anchor = document.createElement("a");
       anchor.classList.add("popup-bubble");
-      anchor.innerHTML = content;
+      anchor.innerHTML = shopName;
 
       // Add click event listener to the anchor tag
-      anchor.addEventListener("click", function () {
-        fetch(`${url}.json`)
-          .then((response) => response.json())
-          .then((shop) => {
-            const shopInfo = document.getElementById("shop-info");
-            const recordsList = shop.records
-              .map((record) => {
-                const createdAt = new Date(record.created_at);
-                const createdAtString = `登録日：${createdAt.getFullYear()}/${
-                  createdAt.getMonth() + 1
-                }/${createdAt.getDate()} ${createdAt.getHours()}:${createdAt
-                  .getMinutes()
-                  .toString()
-                  .padStart(2, "0")}`;
-
-                const elapsedTimeDate = new Date(record.elapsed_time);
-                const elapsedTimeHours = elapsedTimeDate
-                  .getUTCHours()
-                  .toString()
-                  .padStart(2, "0");
-                const elapsedTimeMinutes = elapsedTimeDate
-                  .getUTCMinutes()
-                  .toString()
-                  .padStart(2, "0");
-                const elapsedTimeSeconds = elapsedTimeDate
-                  .getUTCSeconds()
-                  .toString()
-                  .padStart(2, "0");
-                const elapsedTimeMilliseconds = elapsedTimeDate
-                  .getUTCMilliseconds()
-                  .toString()
-                  .padStart(3, "0");
-                const elapsedTimeString = `${elapsedTimeHours}:${elapsedTimeMinutes}'${elapsedTimeSeconds}"${elapsedTimeMilliseconds}`;
-
-                return `<li>${createdAtString} - ${elapsedTimeString}</li>`;
-              })
-              .join("");
-            shopInfo.innerHTML = `
-                <h3>${shop.name}</h3>
-                <p>${shop.address}</p>
-                <div class="d-grid gap-2">
-                  <a class="btn btn-warning" href="${url}/records/new" data-turbo="false">セツゾク！</a>
-                </div>
-                <h4>チャクドンレコード</h4>
-                <ul>${recordsList}</ul>
-              `;
-            showBottomSheet();
-          });
+      anchor.addEventListener("click", function (event) {
+        event.preventDefault();
+        Turbo.visit(`${url}/records/new`, {
+          action: "replace",
+          frame: "shop-info",
+        });
+        showBottomSheet();
       });
 
       // This zero-height div is positioned at the bottom of the bubble.

--- a/app/javascript/timer.js
+++ b/app/javascript/timer.js
@@ -4,7 +4,7 @@ document.addEventListener("turbo:load", () => {
   const startedElement = document.getElementById("started");
   const endedElement = document.getElementById("ended");
 
-  window.history.replaceState(null, null, "/search");
+  // window.history.replaceState(null, null, "/search");
 
   // Format time in HH:MM:SS.mmm
   const formatTime = (time) => {

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -1,3 +1,4 @@
 class LineStatus < ApplicationRecord
   belongs_to :record
+  enum line_type: { inside_the_store: 1, outside_the_store: 2, other: 3 }
 end

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -1,0 +1,3 @@
+class LineStatus < ApplicationRecord
+  belongs_to :record
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,5 +1,7 @@
 class Record < ApplicationRecord
   belongs_to :ramen_shop
+  has_many :line_statuses
+  accepts_nested_attributes_for :line_statuses
 
   def calculate_wait_time!
     self.ended_at = Time.current

--- a/app/views/home/search.html.erb
+++ b/app/views/home/search.html.erb
@@ -5,7 +5,7 @@
 <div id="bottom-sheet" class="hidden">
   <div class="drag-handle" id="drag-handle"></div>
   <button id="close-button">×</button>
-  <div id="shop-info"></div>
+  <turbo-frame id="shop-info"></turbo-frame>
 </div>
 <!-- Loading Spinner -->
 <div id="loading-spinner" class="loading-spinner">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
     <div class="container">
       <%= yield %>
     </div>
+    <%= debug(params) if Rails.env.development? %>
     <%= render 'layouts/footer' %>
   </body>
 </html>

--- a/app/views/records/_records.html.erb
+++ b/app/views/records/_records.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% @ramen_shop.records.each do |record| %>
+    <% if record.created_at.present? %>
+      <li>created_at: <%= record.created_at.getutc.strftime("%F") %> 着丼: <%= record.elapsed_time.getutc.strftime("%H:%M:%S") %></li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+<p><%= @ramen_shop.name %></p>
+<p><%= @ramen_shop.address %></p>
+<%= form_with model: @ramen_shop_record, url: ramen_shop_record_path do |f| %>
+  <div class="form-group">
+    <%= f.label :started_at, class:"form-label" %>
+    <%= f.time_field :started_at, class:"form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :ended_at, class:"form-label" %>
+    <%= f.time_field :ended_at, class:"form-control" %>
+  </div>
+  <%= f.submit '更新', class: "btn btn-warning" %>
+<% end %>

--- a/app/views/records/measure.html.erb
+++ b/app/views/records/measure.html.erb
@@ -8,31 +8,8 @@
   <div id="time">00:00:00.000</div>
 </div>
 <%= form_with model: @ramen_shop_record, url: ramen_shop_record_path do |f| %>
-  <%= f.hidden_field :ramen_shop_id %>
-  <%= f.hidden_field :started_at, id: 'started' %>
   <div class="form-group">
-    <%= f.fields_for :line_statuses do |g| %>
-      <%= g.label :line_number, "人数" %>
-      <%= g.text_field :line_number %>
-      <%= g.label :inside_the_store %>
-      <%= g.radio_button :line_type, :inside_the_store %>
-      <%= g.label :outside_the_storein %>
-      <%= g.radio_button :line_type, :outside_the_storein %>
-      <%= g.label :other %>
-      <%= g.radio_button :line_type, :other %>
-    <% end %>
-    <%= f.submit 'ちゃくどん', id:'ended', class: "btn btn-warning" %>
+    <%= f.hidden_field :started_at, id: 'started' %>
+    <%= f.submit 'ちゃくどん', class: "btn btn-warning" %>
   </div>
 <% end %>
-<div>
-  <ul>
-    <%# @ramen_shop.records.each do |record| %>
-      <%# if record.created_at.present? %>
-      <li>created_at: <%#= record.created_at.getutc.strftime("%F") %> 着丼: <%#= record.elapsed_time.getutc.strftime("%H:%M:%S") %></li>
-      <%# end %>
-      <%# end %>
-    </ul>
-  </div>
-  <div>
-    <%= link_to "Back to ramen shops", ramen_shops_path %>
-  </div>

--- a/app/views/records/measure.html.erb
+++ b/app/views/records/measure.html.erb
@@ -1,0 +1,38 @@
+<% content_for :js do %>
+  <%= javascript_import_module_tag "timer" %>
+<% end %>
+<p style="color: green"><%= notice %></p>
+<p><%= @ramen_shop.name %></p>
+<p><%= @ramen_shop.address %></p>
+<div id="container">
+  <div id="time">00:00:00.000</div>
+</div>
+<%= form_with model: @ramen_shop_record, url: ramen_shop_record_path do |f| %>
+  <%= f.hidden_field :ramen_shop_id %>
+  <%= f.hidden_field :started_at, id: 'started' %>
+  <div class="form-group">
+    <%= f.fields_for :line_statuses do |g| %>
+      <%= g.label :line_number, "人数" %>
+      <%= g.text_field :line_number %>
+      <%= g.label :inside_the_store %>
+      <%= g.radio_button :line_type, :inside_the_store %>
+      <%= g.label :outside_the_storein %>
+      <%= g.radio_button :line_type, :outside_the_storein %>
+      <%= g.label :other %>
+      <%= g.radio_button :line_type, :other %>
+    <% end %>
+    <%= f.submit 'ちゃくどん', id:'ended', class: "btn btn-warning" %>
+  </div>
+<% end %>
+<div>
+  <ul>
+    <%# @ramen_shop.records.each do |record| %>
+      <%# if record.created_at.present? %>
+      <li>created_at: <%#= record.created_at.getutc.strftime("%F") %> 着丼: <%#= record.elapsed_time.getutc.strftime("%H:%M:%S") %></li>
+      <%# end %>
+      <%# end %>
+    </ul>
+  </div>
+  <div>
+    <%= link_to "Back to ramen shops", ramen_shops_path %>
+  </div>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -28,10 +28,3 @@
   </div>
 <% end %>
 <h4>チャクドンレコード</h4>
-<ul>
-  <%# @ramen_shop.records.each do |record| %>
-    <%# if record.created_at.present? %>
-    <li>created_at: <%#= record.created_at.getutc.strftime("%F") %> 着丼: <%#= record.elapsed_time.getutc.strftime("%H:%M:%S") %></li>
-    <%# end %>
-    <%# end %>
-  </ul>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,30 +1,31 @@
-<h3><%= @ramen_shop.name %></h3>
-<p><%= @ramen_shop.address %></p>
-<%= form_with model: @ramen_shop_record, url: ramen_shop_records_path, data: { turbo: false } do |f| %>
-  <%= f.hidden_field :ramen_shop_id %>
-  <%= f.hidden_field :started_at, id: 'started' %>
-  <div class="form-group">
-    <%= f.fields_for :line_statuses do |g| %>
-      <div class="form-group">
-        <%= g.label :line_number, "人数", class:"form-label" %>
-        <%= g.text_field :line_number, class:"form-control" %>
-      </div>
-      <div class="form-group">
-        <div class="form-check">
-          <%= g.label :inside_the_store, class: 'form-check-label' %>
-          <%= g.radio_button :line_type, :inside_the_store, class: 'form-check-input' %>
+<turbo-frame id="shop-info">
+  <h3><%= @ramen_shop.name %></h3>
+  <p><%= @ramen_shop.address %></p>
+  <%= form_with model: @ramen_shop_record, url: ramen_shop_records_path, data: { turbo: false } do |f| %>
+    <%= f.hidden_field :ramen_shop_id %>
+    <%= f.hidden_field :started_at, id: 'started' %>
+    <div class="form-group">
+      <%= f.fields_for :line_statuses do |g| %>
+        <div class="form-group">
+          <%= g.label :line_number, "人数", class:"form-label" %>
+          <%= g.text_field :line_number, class:"form-control" %>
         </div>
-        <div class="form-check">
-          <%= g.label :outside_the_store, class: 'form-check-label' %>
-          <%= g.radio_button :line_type, :outside_the_store, class: 'form-check-input' %>
+        <div class="form-group">
+          <div class="form-check">
+            <%= g.label :inside_the_store, class: 'form-check-label' %>
+            <%= g.radio_button :line_type, :inside_the_store, class: 'form-check-input' %>
+          </div>
+          <div class="form-check">
+            <%= g.label :outside_the_store, class: 'form-check-label' %>
+            <%= g.radio_button :line_type, :outside_the_store, class: 'form-check-input' %>
+          </div>
+          <div class="form-check">
+            <%= g.label :other, class: 'form-check-label' %>
+            <%= g.radio_button :line_type, :other, class: 'form-check-input' %>
+          </div>
         </div>
-        <div class="form-check">
-          <%= g.label :other, class: 'form-check-label' %>
-          <%= g.radio_button :line_type, :other, class: 'form-check-input' %>
-        </div>
-      </div>
-    <% end %>
-    <%= f.submit 'セツゾク', class: "btn btn-warning" %>
-  </div>
-<% end %>
-<h4>チャクドンレコード</h4>
+      <% end %>
+      <%= f.submit 'セツゾク', class: "btn btn-warning" %>
+    </div>
+  <% end %>
+</turbo-frame>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,28 +1,37 @@
-<% content_for :js do %>
-  <%= javascript_import_module_tag "timer" %>
-<% end %>
-<p style="color: green"><%= notice %></p>
-<p><%= @ramen_shop.name %></p>
+<h3><%= @ramen_shop.name %></h3>
 <p><%= @ramen_shop.address %></p>
-<%= form_with model: @ramen_shop_record, url: ramen_shop_records_path, class: 'form-horizontal' do |f| %>
+<%= form_with model: @ramen_shop_record, url: ramen_shop_records_path, data: { turbo: false } do |f| %>
   <%= f.hidden_field :ramen_shop_id %>
   <%= f.hidden_field :started_at, id: 'started' %>
-  <div id="container">
-    <div id="time">00:00:00.000</div>
-  </div>
   <div class="form-group">
-    <%= f.submit 'ちゃくどん', id:'ended', class: "btn btn-warning" %>
+    <%= f.fields_for :line_statuses do |g| %>
+      <div class="form-group">
+        <%= g.label :line_number, "人数", class:"form-label" %>
+        <%= g.text_field :line_number, class:"form-control" %>
+      </div>
+      <div class="form-group">
+        <div class="form-check">
+          <%= g.label :inside_the_store, class: 'form-check-label' %>
+          <%= g.radio_button :line_type, :inside_the_store, class: 'form-check-input' %>
+        </div>
+        <div class="form-check">
+          <%= g.label :outside_the_store, class: 'form-check-label' %>
+          <%= g.radio_button :line_type, :outside_the_store, class: 'form-check-input' %>
+        </div>
+        <div class="form-check">
+          <%= g.label :other, class: 'form-check-label' %>
+          <%= g.radio_button :line_type, :other, class: 'form-check-input' %>
+        </div>
+      </div>
+    <% end %>
+    <%= f.submit 'セツゾク', class: "btn btn-warning" %>
   </div>
 <% end %>
-<div>
-  <ul>
-    <%# @ramen_shop.records.each do |record| %>
-      <%# if record.created_at.present? %>
-      <li>created_at: <%#= record.created_at.getutc.strftime("%F") %> 着丼: <%#= record.elapsed_time.getutc.strftime("%H:%M:%S") %></li>
-      <%# end %>
-      <%# end %>
-    </ul>
-  </div>
-  <div>
-    <%= link_to "Back to ramen shops", ramen_shops_path %>
-  </div>
+<h4>チャクドンレコード</h4>
+<ul>
+  <%# @ramen_shop.records.each do |record| %>
+    <%# if record.created_at.present? %>
+    <li>created_at: <%#= record.created_at.getutc.strftime("%F") %> 着丼: <%#= record.elapsed_time.getutc.strftime("%H:%M:%S") %></li>
+    <%# end %>
+    <%# end %>
+  </ul>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -1,0 +1,5 @@
+<p style="color: green"><%= notice %></p>
+<p><%= @ramen_shop.name %></p>
+<p><%= @ramen_shop.address %></p>
+<p>記録： <%= format_wait_time(@ramen_shop_record.wait_time) %></p>
+<p><%= format_datetime(@ramen_shop_record.created_at) %></p>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -3,3 +3,4 @@
 <p><%= @ramen_shop.address %></p>
 <p>記録： <%= format_wait_time(@ramen_shop_record.wait_time) %></p>
 <p><%= format_datetime(@ramen_shop_record.created_at) %></p>
+<%= link_to '編集', edit_ramen_shop_record_path(@ramen_shop, @ramen_shop_record), class: "btn btn-warning" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,13 @@ Rails.application.routes.draw do
   get '/about', to: 'statics#about'
   get '/search', to: 'home#search'
   get '/near_shops', to: 'ramen_shops#near_shops'
+
   resources :ramen_shops, only: [:index, :show] do
-    resources :records, only: [:new, :create]
+    resources :records, only: [:new, :create, :edit, :update] do
+      get 'measure', to: 'records#measure'
+
+      resources :line_statuses, only: [:index, :new, :create] do
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources :ramen_shops, only: [:index, :show] do
     resources :records, only: [:new, :create, :edit, :update] do
-      get 'measure', to: 'records#measure'
+      get 'measure', on: :member
 
       resources :line_statuses, only: [:index, :new, :create] do
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get '/near_shops', to: 'ramen_shops#near_shops'
 
   resources :ramen_shops, only: [:index, :show] do
-    resources :records, only: [:new, :create, :edit, :update] do
+    resources :records, only: [:show, :new, :create, :edit, :update] do
       get 'measure', on: :member
 
       resources :line_statuses, only: [:index, :new, :create] do

--- a/db/migrate/20230521211816_create_line_statuses.rb
+++ b/db/migrate/20230521211816_create_line_statuses.rb
@@ -1,0 +1,12 @@
+class CreateLineStatuses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :line_statuses do |t|
+      t.references :record, null: false, foreign_key: true
+      t.integer :line_number
+      t.integer :line_type
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_09_075729) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_21_211816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "line_statuses", force: :cascade do |t|
+    t.bigint "record_id", null: false
+    t.integer "line_number"
+    t.integer "line_type"
+    t.string "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_id"], name: "index_line_statuses_on_record_id"
+  end
 
   create_table "ramen_shops", force: :cascade do |t|
     t.string "name"
@@ -34,5 +44,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_09_075729) do
     t.index ["ramen_shop_id"], name: "index_records_on_ramen_shop_id"
   end
 
+  add_foreign_key "line_statuses", "records"
   add_foreign_key "records", "ramen_shops"
 end

--- a/spec/models/line_status_spec.rb
+++ b/spec/models/line_status_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LineStatus, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## やったこと
Recordに紐づく行列状態を表すLineStatusモデルを追加し、待ち時間計測開始から完了までの一連の流れを大幅見直し。
- LineStatusモデル
   - Recordに紐づく行列状態を表すモデルを追加
   - enumでline_typeを定義し、Recordとの関係を定義
- Recordコントローラ
  - queue_numberを削除
  - newアクションでは空のレコードインスタンスを作るように変更
  - createアクションではLineStatusのみ作成するよう変更
  - measureアクションでstarted_atを更新して記録開始するよう変更
  - updateアクションで取得したended_atをもとにwait_timeを計算するよう変更
  - Record作成後は作成したレコード自体に遷移するよう変更
   - ストロングパラメータでLineStatusも許可
- View 
  - レコード一覧をパーシャル化
  - edit画面を作成
  - タイマー計測画面はmeasureテンプレートへ移管
  - new画面では最初の行列状態のみ投稿できるように変更
- ヘルパーメソッド
  - format_wait_timeをapplicationヘルパーへ移管
  - 2023年5月28(日)00:00と表示するformat_datetimeヘルパーを作成
- app/javascript/map.js
  -  Popupクラスの引数をshopNameへ変更
  - Popup表示するコンテンツをサーバーでレンダリングしてTurbo置換するよう変更
- その他
  - 開発環境でparamsの内容を表示できるようレイアウトファイルを編集

## やっていないこと（今後実装予定）
- Record編集画面へ動線整備
- Record一覧画面への動線整備