### PR TITLE
bootstrap_form導入とバグ修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem "jquery-rails"
 gem 'enum_help'
 gem 'kaminari'
 gem 'ransack'
+gem "bootstrap_form"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 2.11.6, < 3)
       sassc-rails (>= 2.0.0)
+    bootstrap_form (5.2.2)
+      actionpack (>= 6.0)
+      activemodel (>= 6.0)
     builder (3.2.4)
     capybara (3.39.0)
       addressable
@@ -277,6 +280,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   bootstrap
+  bootstrap_form
   capybara
   dartsass-rails
   debug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -200,3 +200,8 @@ textarea {
 .container {
   max-width: 720px;
 }
+
+label.required:after {
+  content:" *";
+  color: red;
+}

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -22,8 +22,6 @@ class RecordsController < ApplicationController
   end
 
   def measure
-    @line_status = @record.line_statuses.build
-
     if @record.update(started_at: Time.current)
       flash.notice = "セツゾクしました"
     else
@@ -56,6 +54,6 @@ class RecordsController < ApplicationController
   end
 
   def record_param
-    params.require(:record).permit(:ramen_shop_id, :started_at, :ended_at, line_statuses_attributes: [:line_number, :line_type])
+    params.require(:record).permit(:ramen_shop_id, :started_at, :ended_at, line_statuses_attributes: [:line_number, :line_type, :comment])
   end
 end

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -1,4 +1,7 @@
 class LineStatus < ApplicationRecord
   belongs_to :record
   enum line_type: { inside_the_store: 1, outside_the_store: 2, other: 3 }
+
+  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :comment, length: { maximum: 200, too_long: "最大%{count}文字まで使えます" }
 end

--- a/app/views/line_statuses/_form.html.erb
+++ b/app/views/line_statuses/_form.html.erb
@@ -1,23 +1,8 @@
-<div class="mb-3">
-  <%= f.label :line_number, "人数", class:"form-label" %>
-  <%= f.text_field :line_number, class:"form-control" %>
-</div>
-<div class="mb-3">
-  <div class="form-check">
-    <%= f.label :line_type, "店内", class: 'form-check-label' %>
-    <%= f.radio_button :line_type, :inside_the_store, class: 'form-check-input' %>
-  </div>
-  <div class="form-check">
-    <%= f.label :line_type, "店外", class: 'form-check-label' %>
-    <%= f.radio_button :line_type, :outside_the_store, class: 'form-check-input' %>
-  </div>
-  <div class="form-check">
-    <%= f.label :line_type, "その他", class: 'form-check-label' %>
-    <%= f.radio_button :line_type, :other, class: 'form-check-input' %>
-  </div>
-</div>
-<div class="mb-3">
-  <%= f.label :comment, 'コメント', class:"form-label" %>
-  <%= f.text_area :comment, class:"form-control" %>
-</div>
-<%= f.submit '報告', class: "btn btn-warning", data: { disable_with: '報告中...' } %>
+<%= f.text_field :line_number %>
+<%= f.form_group :line_type, label: { text: "接続先" } do %>
+  <%= f.radio_button :line_type, :inside_the_store, label: "店内", checked: true %>
+  <%= f.radio_button :line_type, :outside_the_store, label: "店外" %>
+  <%= f.radio_button :line_type, :other, label: "その他" %>
+<% end %>
+<%= f.text_area :comment, label: { text: "ひとこと" } %>
+<%= f.submit yield(:button_text), class: "btn btn-sm btn-warning", data: { disable_with: '報告中...' } %>

--- a/app/views/line_statuses/edit.html.erb
+++ b/app/views/line_statuses/edit.html.erb
@@ -1,4 +1,5 @@
 <h1>待ち状況を編集する</h1>
-<%= form_with model: @line_status do |form| %>
+<%= bootstrap_form_with model: @line_status do |form| %>
   <%= render "form", f: form %>
+  <%= form.submit '更新', class: "btn btn-sm btn-warning", data: { disable_with: '更新中...' } %>
 <% end %>

--- a/app/views/line_statuses/new.html.erb
+++ b/app/views/line_statuses/new.html.erb
@@ -1,4 +1,5 @@
 <h1>待ち状況を登録する</h1>
-<%= form_with model: @record_line_status, url: record_line_statuses_path do |form| %>
+<%= bootstrap_form_with model: @record_line_status, url: record_line_statuses_path do |form| %>
   <%= render "form", f: form %>
+  <%= form.submit '登録', class: "btn btn-sm btn-warning", data: { disable_with: '登録中...' } %>
 <% end %>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,31 +1,12 @@
 <turbo-frame id="shop-info">
   <h3><%= @ramen_shop.name %></h3>
   <p><%= @ramen_shop.address %></p>
-  <%= form_with model: @ramen_shop_record, url: ramen_shop_records_path, data: { turbo: false } do |f| %>
+  <%= bootstrap_form_with model: @ramen_shop_record, url: ramen_shop_records_path, data: { turbo: false } do |f| %>
     <%= f.hidden_field :ramen_shop_id %>
     <%= f.hidden_field :started_at, id: 'started' %>
-    <div class="form-group">
-      <%= f.fields_for :line_statuses do |g| %>
-        <div class="form-group">
-          <%= g.label :line_number, "人数", class:"form-label" %>
-          <%= g.text_field :line_number, class:"form-control" %>
-        </div>
-        <div class="form-group">
-          <div class="form-check">
-            <%= g.label '店内', class: 'form-check-label' %>
-            <%= g.radio_button :line_type, :inside_the_store, class: 'form-check-input' %>
-          </div>
-          <div class="form-check">
-            <%= g.label '店外', class: 'form-check-label' %>
-            <%= g.radio_button :line_type, :outside_the_store, class: 'form-check-input' %>
-          </div>
-          <div class="form-check">
-            <%= g.label 'その他', class: 'form-check-label' %>
-            <%= g.radio_button :line_type, :other, class: 'form-check-input' %>
-          </div>
-        </div>
-      <% end %>
-      <%= f.submit 'セツゾク', class: "btn btn-warning" %>
-    </div>
+    <%= f.fields_for :line_statuses do |form| %>
+      <%= render "line_statuses/form", f: form %>
+    <% end %>
+    <%= f.submit '接続', class: "btn btn-sm btn-warning", data: { disable_with: '接続中...' } %>
   <% end %>
 </turbo-frame>


### PR DESCRIPTION
## やったこと
- bootstrap_formをインストールしline_statuses用フォームに適用
- 必須項目に*を表示するようcss追加
- LineStatusにバリデーション追加
- records#update時に空のline_statusesが生成されてしまうバグを修正 fixed #16 