### PR TITLE
searchページのスピナー表示方法の改善

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,7 +38,7 @@ textarea {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100svh;
+  height: 100svh
 }
 
 [data-timer-target="time"] {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,9 +38,8 @@ textarea {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100svh;
 }
-
 
 [data-timer-target="time"] {
   text-align: center;
@@ -48,10 +47,6 @@ textarea {
   margin: .5rem;
   padding: 1rem;
   font-family: sans-serif;
-}
-
-#map {
-  height: 100%;
 }
 
 /* The popup bubble styling. */
@@ -109,55 +104,9 @@ textarea {
   width: 200px;
 }
 
-#bottom-sheet {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 50vh;
-  background-color: white;
-  overflow-y: scroll;
-  padding: 1rem;
-  box-sizing: border-box;
-  z-index: 1000;
-  transition: all 0.3s, transform 0.3s;
-  word-break: break-word;
-}
-
-#close-button {
-  position: absolute;
-  top: 0.5rem;
-  right: 1rem;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  font-weight: bold;
-  cursor: pointer;
-}
-
-.hidden {
-  transform: translateY(100%);
-}
-
-.shown {
-  transform: translateY(0);
-}
-.drag-handle {
-  position: absolute;
-  top: 5px;
-  left: 50%;
-  width: 30px;
-  height: 10px;
-  background-color: #ccc;
-  border-radius: 5px;
-  cursor: grab;
-  transform: translateX(-50%);
-  z-index: 1001;
-}
-
 .loading-spinner {
   width: 100%;
-  height: 100vh;
+  height: calc(100svh - 56px - 76px);
   background-color: rgba(255, 255, 255, 0.8);
   display: flex;
   justify-content: center;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,20 +25,11 @@ textarea {
   margin-bottom: 10px;
 }
 
-#map-container {
-  position: relative;
-  width: 100vw;
-  height: 0;
-  padding-bottom: 75%; /* 地図幅と同じ比率に設定 */
-  margin: 0 calc(50% - 50vw);
-}
-
 #map {
-  position: absolute;
-  top: 0;
-  left: 0;
+  margin: 0 !important;
+  padding: 0 !important;
   width: 100%;
-  height: 100svh
+  height: calc(100svh - 56px);
 }
 
 [data-timer-target="time"] {

--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -108,10 +108,12 @@ window.initMap = () => {
           });
       },
       function () {
+        document.getElementById("loading-spinner").style.display = "none";
         alert("現在地が取得できませんでした");
       }
     );
   } else {
+    document.getElementById("loading-spinner").style.display = "none";
     alert("お使いのブラウザではサポートされていません");
   }
 };

--- a/app/views/home/search.html.erb
+++ b/app/views/home/search.html.erb
@@ -4,8 +4,8 @@
 <% content_for :js do %>
   <%= javascript_import_module_tag "map" %>
 <% end %>
-<div id="map"></div>
 <div id="loading-spinner" class="loading-spinner">
   <div class="spinner"></div>
 </div>
+<div id="map"></div>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" defer></script>

--- a/app/views/home/search.html.erb
+++ b/app/views/home/search.html.erb
@@ -1,7 +1,10 @@
+<% content_for :meta do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
 <% content_for :js do %>
   <%= javascript_import_module_tag "map" %>
 <% end %>
-<div id="map" style="height: 100vh;"></div>
+<div id="map"></div>
 <div id="loading-spinner" class="loading-spinner">
   <div class="spinner"></div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,12 +14,10 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <div class="row">
-        <div class="mb-4">
-          <div id="flash">
-            <%= render "flash" %>
-          </div>
-          <%= yield %>
+        <div id="flash">
+          <%= render "flash" %>
         </div>
+        <%= yield %>
       </div>
     </div>
     <%= debug(params) if Rails.env.development? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= yield(:meta) %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= yield(:js) %>


### PR DESCRIPTION
## やったこと
- searchページではキャッシュを利用しないよう設定
- map.js内でエラーが出た場合はスピナーを非表示にするよう設定
- その他
  - 不要なCSSを削除
  - マップとスピナーの表示領域を変更
