### PR TITLE
ユーザー情報の一覧表示・編集・削除機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'enum_help'
 gem 'kaminari'
 gem 'ransack'
 gem "bootstrap_form"
+gem 'faker'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -80,4 +80,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -339,6 +341,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   kaminari
+  launchy
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.2.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     geocoder (1.8.1)
     globalid (1.1.0)
@@ -335,6 +337,7 @@ DEPENDENCIES
   dotenv-rails
   enum_help
   factory_bot_rails
+  faker
   geocoder
   htmlbeautifier
   importmap-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -169,3 +169,15 @@ aside {
 .gravatar_edit {
   margin-top: 15px;
 }
+
+/* Users index */
+
+.users {
+  list-style: none;
+  margin: 0;
+  li {
+    overflow: auto;
+    padding: 10px 0;
+    border-bottom: 1px solid #eeeeee;
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,10 +6,11 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])
+      forwarding_url = session[:forwarding_url]
       reset_session
       params[:session][:remember_me] == '1' ? remember(user) : forget(user)
       log_in user
-      redirect_to user, notice: 'ログインしました'
+      redirect_to forwarding_url || user, notice: 'ログインしました'
     else
       flash.now.alert = 'ログインに失敗しました'
       render 'new', status: :unprocessable_entity

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < ApplicationController
   def new
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])
@@ -16,7 +16,7 @@ class SessionsController < ApplicationController
       render 'new', status: :unprocessable_entity
     end
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def destroy
     log_out if logged_in?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update]
   before_action :correct_user, only: [:edit, :update]
+
+  def index
+    @users = User.all
+  end
 
   def show
     @user = User.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
+
   def show
     @user = User.find(params[:id])
   end
@@ -20,12 +23,9 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find(params[:id])
   end
 
   def update
-    @user = User.find(params[:id])
-
     if @user.update(user_params)
       flash.notice = 'ユーザー情報を更新しました'
       redirect_to @user
@@ -39,5 +39,17 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email, :password,
                                  :password_confirmation)
+  end
+
+  def logged_in_user
+    unless logged_in?
+      flash.alert = 'ログインしてください'
+      redirect_to login_url, status: :see_other
+    end
+  end
+
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to root_path, status: :see_other unless current_user?(@user)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :logged_in_user, only: %i[index edit update destroy]
+  before_action :correct_user, only: %i[edit update]
   before_action :admin_user, only: :destroy
 
   def index
@@ -15,6 +15,9 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
+  def edit
+  end
+
   def create
     @user = User.new(user_params)
 
@@ -25,9 +28,6 @@ class UsersController < ApplicationController
     else
       render 'new', status: :unprocessable_entity
     end
-  end
-
-  def edit
   end
 
   def update
@@ -52,19 +52,19 @@ class UsersController < ApplicationController
   end
 
   def logged_in_user
-    unless logged_in?
-      store_location
-      flash.alert = 'ログインしてください'
-      redirect_to login_url, status: :see_other
-    end
+    return if logged_in?
+
+    store_location
+    flash.alert = 'ログインしてください'
+    redirect_to login_url, status: :see_other
   end
 
   def correct_user
     @user = User.find(params[:id])
-    unless current_user?(@user)
-      flash.alert = '不正なアクセスです'
-      redirect_to root_path, status: :see_other
-    end
+    return if current_user?(@user)
+
+    flash.alert = '不正なアクセスです'
+    redirect_to root_path, status: :see_other
   end
 
   def admin_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user, only: [:edit, :update]
+  before_action :admin_user, only: :destroy
 
   def index
     @users = User.page(params[:page])
@@ -38,6 +39,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    User.find(params[:id]).destroy
+    redirect_to users_url, status: :see_other, notice: 'ユーザーを削除しました'
+  end
+
   private
 
   def user_params
@@ -59,5 +65,9 @@ class UsersController < ApplicationController
       flash.alert = '不正なアクセスです'
       redirect_to root_path, status: :see_other
     end
+  end
+
+  def admin_user
+    redirect_to root_url, status: :see_other, notice: '不正なアクセスです' unless current_user.admin?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :correct_user, only: [:edit, :update]
 
   def index
-    @users = User.all
+    @users = User.page(params[:page])
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,21 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+
+    if @user.update(user_params)
+      flash.notice = 'ユーザー情報を更新しました'
+      redirect_to @user
+    else
+      render 'edit', status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,6 +43,7 @@ class UsersController < ApplicationController
 
   def logged_in_user
     unless logged_in?
+      store_location
       flash.alert = 'ログインしてください'
       redirect_to login_url, status: :see_other
     end
@@ -50,6 +51,9 @@ class UsersController < ApplicationController
 
   def correct_user
     @user = User.find(params[:id])
-    redirect_to root_path, status: :see_other unless current_user?(@user)
+    unless current_user?(@user)
+      flash.alert = '不正なアクセスです'
+      redirect_to root_path, status: :see_other
+    end
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -24,6 +24,10 @@ module SessionsHelper
     end
   end
 
+  def current_user?(user)
+    user && user == current_user
+  end
+
   def logged_in?
     !current_user.nil?
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -44,4 +44,8 @@ module SessionsHelper
     @current_user = nil
   end
   # rubocop:enable Rails/HelperInstanceVariable
+
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,6 @@
 module UsersHelper
-  def gravatar_for(user, size: 80)
+  def gravatar_for(user, options = { size: 80 })
+    size         = options[:size]
     gravatar_id  = Digest::MD5.hexdigest(user.email.downcase)
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: 'gravatar')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: true
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   def self.digest(string)
     cost = if ActiveModel::SecurePassword.min_cost

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,9 @@
+<%= bootstrap_form_with model: @user do |f|%>
+  <%= f.text_field :name, label: "ニックネーム" %>
+  <%= f.email_field :email, label: "メールアドレス" %>
+  <%= f.password_field :password, label: "パスワード" , help: '6文字以上入力してね' %>
+  <%= f.password_field :password_confirmation, label: "パスワード(確認)" %>
+  <div class="d-grid">
+    <%= f.submit yield(:button_text) %>
+  </div>
+<% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,4 +1,8 @@
 <li>
   <%= gravatar_for user, size: 32 %>
   <%= link_to user.name, user_path(user) %>
+  <% if current_user.admin? && !current_user?(user) %>
+    | <%= link_to "削除", user, data: { "turbo-method": :delete,
+                                          turbo_confirm: "本当に削除しますか？" } %>
+  <% end %>
 </li>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,4 @@
+<li>
+  <%= gravatar_for user, size: 32 %>
+  <%= link_to user.name, user_path(user) %>
+</li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,9 @@
+<% provide(:button_text, '更新する') %>
+<h1>ユーザー編集</h1>
+<div class="col-md-6">
+  <%= render 'form' %>
+  <div class="gravatar_edit">
+    <%= gravatar_for @user %>
+    <a href="https://gravatar.com/emails" target="_blank">変更する</a>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,6 @@
 <h1>すべてのユーザー</h1>
+<%= paginate @users %>
 <ul class="users">
   <%= render @users %>
 </ul>
+<%= paginate @users %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,4 @@
+<h1>すべてのユーザー</h1>
+<ul class="users">
+  <%= render @users %>
+</ul>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,12 +1,5 @@
+<% provide(:button_text, '登録する') %>
 <h1>ユーザー登録</h1>
 <div class="col-md-6">
-  <%= bootstrap_form_with model: @user do |f|%>
-    <%= f.text_field :name, label: "ニックネーム" %>
-    <%= f.email_field :email, label: "メールアドレス" %>
-    <%= f.password_field :password, label: "パスワード" , help: '6文字以上入力してね' %>
-    <%= f.password_field :password_confirmation, label: "パスワード(確認)" %>
-    <div class="d-grid">
-      <%= f.submit "登録する" %>
-    </div>
-  <% end %>
+  <%= render 'form' %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,5 +5,6 @@
       <%= @user.name %>
     </h1>
   </section>
-  <%= link_to 'すべてのユーザーをみる', users_path %>
+  <p><%= link_to 'ユーザー情報を編集する', edit_user_path(@user) if current_user?(@user) %></p>
+  <p><%= link_to 'すべてのユーザーをみる', users_path %></p>
 </aside>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,4 +5,5 @@
       <%= @user.name %>
     </h1>
   </section>
+  <%= link_to 'すべてのユーザーをみる', users_path %>
 </aside>

--- a/db/migrate/20230703222028_add_admin_to_users.rb
+++ b/db/migrate/20230703222028_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_30_223304) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_222028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_223304) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "remember_digest"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,8 @@ end
 User.create!(name:  "Example User",
   email: "example@railstutorial.org",
   password:              "foobar",
-  password_confirmation: "foobar")
+  password_confirmation: "foobar",
+  admin: true)
 
 99.times do |n|
 name  = Faker::Name.name

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,3 +40,18 @@ shops.each do |shop|
 
   counter += 1
 end
+
+User.create!(name:  "Example User",
+  email: "example@railstutorial.org",
+  password:              "foobar",
+  password_confirmation: "foobar")
+
+99.times do |n|
+name  = Faker::Name.name
+email = "example-#{n+1}@railstutorial.org"
+password = "password"
+User.create!(name:  name,
+    email: email,
+    password:              password,
+    password_confirmation: password)
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     email { 'user@example.com' }
     password { 'foobar' }
     password_confirmation { 'foobar' }
+
+    factory :other_user do
+      name { 'Other User' }
+      email { 'other@example.com' }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,15 +4,18 @@ FactoryBot.define do
     email { 'user@example.com' }
     password { 'foobar' }
     password_confirmation { 'foobar' }
+    admin { true }
 
     factory :other_user do
       name { 'Other User' }
       email { 'other@example.com' }
+      admin { false }
     end
 
     factory :all_user do
       sequence(:name) { |n| "tester#{n}" }
       sequence(:email) { |n| "tester#{n}@example.com" }
+      admin { false }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,5 +9,10 @@ FactoryBot.define do
       name { 'Other User' }
       email { 'other@example.com' }
     end
+
+    factory :all_user do
+      sequence(:name) { |n| "tester#{n}" }
+      sequence(:email) { |n| "tester#{n}@example.com" }
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe 'Users' do
     end
   end
 
+  describe 'GET /users' do
+    it 'redirects index when not logged in' do
+      get users_path
+      expect(response).to redirect_to login_url
+    end
+  end
+
   describe 'POST /users #create' do
     it 'cannot create account with invalid information' do
       expect {

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -58,5 +58,19 @@ RSpec.describe 'Users' do
                                                email: user.email } }
       expect(response).to redirect_to root_url
     end
+
+    it 'successfully edits with friendly forwarding' do
+      get edit_user_path(user)
+      log_in_as(user)
+      expect(response).to redirect_to edit_user_path(user)
+      name  = "Foo Bar"
+      email = "foo@bar.com"
+      patch user_path(user), params: { user: { name: name,
+                                               email: email } }
+      expect(response).to redirect_to user
+      user.reload
+      expect(user.name).to eq name
+      expect(user.email).to eq email
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -30,4 +30,33 @@ RSpec.describe 'Users' do
       }.to change(User, :count).by(1)
     end
   end
+
+  describe 'EDIT /user/:id' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:other_user) }
+
+    it 'redirects to login_path when not logged_in' do
+      get edit_user_path(user)
+      expect(response).to redirect_to login_path
+    end
+
+    it 'redirects to login_path when not logged_in' do
+      patch user_path(user), params: { user: { name: user.name,
+                                               email: user.email } }
+      expect(response).to redirect_to login_path
+    end
+
+    it 'redirects to root_url logged in as wrong user' do
+      log_in_as(user)
+      get edit_user_path(other_user)
+      expect(response).to redirect_to root_url
+    end
+
+    it 'redirects to root_url logged in as wrong user' do
+      log_in_as(user)
+      patch user_path(other_user), params: { user: { name: user.name,
+                                               email: user.email } }
+      expect(response).to redirect_to root_url
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -38,18 +38,12 @@ RSpec.describe 'Users' do
     end
   end
 
-  describe 'EDIT /user/:id' do
+  describe 'GET /user/:id/edit' do
     let(:user) { create(:user) }
     let(:other_user) { create(:other_user) }
 
     it 'redirects to login_path when not logged_in' do
       get edit_user_path(user)
-      expect(response).to redirect_to login_path
-    end
-
-    it 'redirects to login_path when not logged_in' do
-      patch user_path(user), params: { user: { name: user.name,
-                                               email: user.email } }
       expect(response).to redirect_to login_path
     end
 
@@ -59,19 +53,12 @@ RSpec.describe 'Users' do
       expect(response).to redirect_to root_url
     end
 
-    it 'redirects to root_url logged in as wrong user' do
-      log_in_as(user)
-      patch user_path(other_user), params: { user: { name: user.name,
-                                               email: user.email } }
-      expect(response).to redirect_to root_url
-    end
-
     it 'successfully edits with friendly forwarding' do
       get edit_user_path(user)
       log_in_as(user)
       expect(response).to redirect_to edit_user_path(user)
-      name  = "Foo Bar"
-      email = "foo@bar.com"
+      name  = 'Foo Bar'
+      email = 'foo@bar.com'
       patch user_path(user), params: { user: { name: name,
                                                email: email } }
       expect(response).to redirect_to user
@@ -85,14 +72,28 @@ RSpec.describe 'Users' do
     let(:user) { create(:user) }
     let(:other_user) { create(:other_user) }
 
-    it "does not allow the admin attribute to be edited via the web" do
+    it 'redirects to login_path when not logged_in' do
+      patch user_path(user), params: { user: { name: user.name,
+                                               email: user.email } }
+      expect(response).to redirect_to login_path
+    end
+
+    it 'redirects to root_url logged in as wrong user' do
+      log_in_as(user)
+      patch user_path(other_user), params: { user: { name: user.name,
+                                                     email: user.email } }
+      expect(response).to redirect_to root_url
+    end
+
+    it 'does not allow the admin attribute to be edited via the web' do
       log_in_as(other_user)
-      expect(other_user.admin?).to be_falsy
+      expect(other_user).to_not be_admin
       patch user_path(other_user), params: {
-                                      user: { password:              "password",
-                                              password_confirmation: "password",
-                                              admin: true } }
-      expect(other_user.reload.admin?).to be_falsy
+        user: { password: 'password',
+                password_confirmation: 'password',
+                admin: true }
+      }
+      expect(other_user.reload).to_not be_admin
     end
   end
 

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,15 +1,29 @@
 module LoginSupport
-  def is_logged_in?
-    !session[:user_id].nil?
+  module System
+    def log_in_as(user)
+      visit login_path
+
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: user.password
+      click_button 'ログインする'
+    end
   end
 
-  def log_in_as(user, password: user.password, remember_me: '1')
-    post login_path, params: { session: { email: user.email,
-                                          password: password,
-                                          remember_me: remember_me } }
+  module Request
+    def is_logged_in?
+      !session[:user_id].nil?
+    end
+
+    def log_in_as(user, password: user.password, remember_me: '1')
+      post login_path, params: { session: { email: user.email,
+                                            password: password,
+                                            remember_me: remember_me } }
+    end
   end
 end
 
 RSpec.configure do |config|
-  config.include LoginSupport
+  config.include LoginSupport::System, type: :system
+  config.include LoginSupport::Request, type: :request
+  config.include LoginSupport::Request, type: :helper
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -49,4 +49,21 @@ RSpec.describe 'Users' do
       expect(page).to have_content 'Passwordの入力が一致しません'
     }.to_not change(User, :count)
   end
+
+  describe 'index' do
+    before do
+      30.times do
+        create(:all_user)
+      end
+    end
+
+    it 'shows users including pagination' do
+      log_in_as(user)
+      visit users_path
+      expect(page).to have_selector('.pagination')
+      User.page(1).each do |user|
+        expect(page).to have_link user.name, href: user_path(user)
+      end
+    end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -55,12 +55,10 @@ RSpec.describe 'Users' do
     let!(:non_admin) { create(:other_user) }
 
     before do
-      30.times do
-        create(:all_user)
-      end
+      create_list(:all_user, 30)
     end
 
-    context 'as admin' do
+    context 'with admin' do
       it 'shows users including pagination and delete link' do
         log_in_as(admin)
         visit users_path
@@ -68,9 +66,7 @@ RSpec.describe 'Users' do
         first_page_of_users = User.page(1)
         first_page_of_users.each do |user|
           expect(page).to have_link user.name, href: user_path(user)
-          unless user == admin
-            expect(page).to have_link '削除', href: user_path(user)
-          end
+          expect(page).to have_link '削除', href: user_path(user) unless user == admin
         end
         expect {
           click_link '削除', href: user_path(non_admin)
@@ -78,7 +74,7 @@ RSpec.describe 'Users' do
       end
     end
 
-    context 'as non-admin' do
+    context 'with non-admin' do
       it 'shows users not including delete link' do
         log_in_as(non_admin)
         visit users_path

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Users' do
   end
 
   scenario 'user cannot update the account with invalid information' do
+    log_in_as(user)
     visit edit_user_path(user)
     expect {
       fill_in 'ニックネーム', with: 'Foo bar'
@@ -34,6 +35,7 @@ RSpec.describe 'Users' do
   end
 
   scenario 'user update the account with valid information' do
+    log_in_as(user)
     visit edit_user_path(user)
     expect {
       fill_in 'ニックネーム', with: ''

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Users' do
     driven_by(:rack_test)
   end
 
+  let(:user) { create(:user) }
+
   scenario 'user creates an account with valid information' do
     visit new_user_path
     expect {
@@ -16,5 +18,33 @@ RSpec.describe 'Users' do
       expect(page).to have_content '登録が完了しました'
       expect(page).to have_content 'もりを'
     }.to change(User, :count).by(1)
+  end
+
+  scenario 'user cannot update the account with invalid information' do
+    visit edit_user_path(user)
+    expect {
+      fill_in 'ニックネーム', with: 'Foo bar'
+      fill_in 'メールアドレス', with: 'foo@bar.com'
+      fill_in 'パスワード', with: ''
+      fill_in 'パスワード(確認)', with: ''
+      click_button '更新する'
+      expect(page).to have_content 'ユーザー情報を更新しました'
+      expect(page).to have_content 'Foo bar'
+    }.to_not change(User, :count)
+  end
+
+  scenario 'user update the account with valid information' do
+    visit edit_user_path(user)
+    expect {
+      fill_in 'ニックネーム', with: ''
+      fill_in 'メールアドレス', with: 'foo@invalid'
+      fill_in 'パスワード', with: 'foo'
+      fill_in 'パスワード(確認)', with: 'bar'
+      click_button '更新する'
+      expect(page).to have_content '入力してください'
+      expect(page).to have_content '不正な値です'
+      expect(page).to have_content '6文字以上で入力してください'
+      expect(page).to have_content 'Passwordの入力が一致しません'
+    }.to_not change(User, :count)
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -82,4 +82,17 @@ RSpec.describe 'Users' do
       end
     end
   end
+
+  describe 'show' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:other_user) }
+
+    it 'shows edit_user_path when vist current_user path' do
+      log_in_as(user)
+      visit user_path(other_user)
+      expect(page).to_not have_link 'ユーザー情報を編集する', href: edit_user_path(other_user)
+      visit user_path(user)
+      expect(page).to have_link 'ユーザー情報を編集する', href: edit_user_path(user)
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
- ユーザー情報の一覧表示・編集・削除機能を追加
  - adminカラムを追加
  - 更新時はパスワードを入力しなくてもいいよう`allow_nil: true`を設定
  - 実装内容を検証するspecを追加
- 認可に応じてユーザー情報を制御できるよう実装
  - ログインユーザ自身に対してのみユーザー更新可能
  - 管理者のみユーザー削除可能
  - 特定ページへのアクセスでログインを求められた場合、ログイン後そのページへ移動するフレンドリーフォワーディングを実装
- その他 
  - ユーザーデーター用にseed.rbを更新
  - gemのfakeとlaunchyを導入

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス