### PR TITLE
MailerによるUserアカウント有効化機能を追加

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,2 @@
+class AccountActivationsController < ApplicationController
+end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,2 +1,12 @@
 class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      redirect_to user, notice: 'アカウントが有効化されました'
+    else
+      redirect_to root_path, alert: '無効な有効化リンクです'
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,12 @@ class UsersController < ApplicationController
   before_action :admin_user, only: :destroy
 
   def index
-    @users = User.page(params[:page])
+    @users = User.where(activated: true).page(params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_path and return unless @user.activated
   end
 
   def new
@@ -22,9 +23,8 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      reset_session
-      log_in @user
-      redirect_to @user, notice: '登録が完了しました'
+      @user.send_activation_email
+      redirect_to root_path, notice: 'メールを確認してアカウントを有効にしてください'
     else
       render 'new', status: :unprocessable_entity
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,7 +17,7 @@ module SessionsHelper
       @current_user = user if user && session[:session_token] == user.session_token
     elsif (user_id = cookies.encrypted[:user_id])
       user = User.find_by(id: user_id)
-      if user&.authenticated?(cookies[:remember_token])
+      if user&.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'tontonka2@gmail.com'
+  default from: 'noreply@mail.tyakudon.com'
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'tontonka2@gmail.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,12 @@
+class UserMailer < ApplicationMailer
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: 'アカウントの有効化に関して'
+  end
+
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,8 +5,8 @@ class UserMailer < ApplicationMailer
   end
 
   def password_reset
-    @greeting = "Hi"
+    @greeting = 'Hi'
 
-    mail to: "to@example.org"
+    mail to: 'to@example.org'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
+  attr_accessor :remember_token, :activation_token
+  before_save :downcase_email
+  before_create :create_activation_digest
 
-  before_save { email.downcase! }
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
@@ -44,4 +45,15 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, nil)
   end
   # rubocop:enable Rails/SkipsModelValidations
+
+  private
+
+  def downcase_email
+    self.email.downcase!
+  end
+
+  def create_activation_digest
+    self.activation_token = User.new_token
+    self.activation_digest = User.digest(activation_token)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,16 +35,26 @@ class User < ApplicationRecord
     remember_digest || remember
   end
 
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
 
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   def forget
     update_attribute(:remember_digest, nil)
   end
   # rubocop:enable Rails/SkipsModelValidations
+
+  def activate
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zone.now)
+  end
+
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token, :activation_token
+
   before_save :downcase_email
   before_create :create_activation_digest
 
@@ -45,12 +46,12 @@ class User < ApplicationRecord
   def forget
     update_attribute(:remember_digest, nil)
   end
-  # rubocop:enable Rails/SkipsModelValidations
 
   def activate
     update_attribute(:activated, true)
     update_attribute(:activated_at, Time.zone.now)
   end
+  # rubocop:enable Rails/SkipsModelValidations
 
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
@@ -59,7 +60,7 @@ class User < ApplicationRecord
   private
 
   def downcase_email
-    self.email.downcase!
+    email.downcase!
   end
 
   def create_activation_digest

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,5 @@
+<h1>チャクドン</h1>
+<p>こんにちは <%= @user.name %></p>
+<p>チャクドンへようこそ！</p>
+<p>以下のリンクをクリックしてアカウントを有効化してください。</p>
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,4 @@
+こんにちは <%= @user.name %>
+チャクドンへようこそ！
+以下のリンクをクリックしてアカウントを有効化してください。
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,18 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'tyakudon.onrender.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :port           => 587,
+    :address        => 'smtp.mailgun.org',
+    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         => host,
+    :authentication => :plain,
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
+  config.action_mailer.default_url_options = { host: 'example.com' }
 
   config.action_mailer.perform_caching = false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
     end
   end
   resources :users
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20230705092225_add_activation_to_users.rb
+++ b/db/migrate/20230705092225_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_03_222028) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_05_092225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_222028) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,7 +45,9 @@ User.create!(name:  "Example User",
   email: "example@railstutorial.org",
   password:              "foobar",
   password_confirmation: "foobar",
-  admin: true)
+  admin: true,
+  activated: true,
+  activated_at: Time.zone.now)
 
 99.times do |n|
 name  = Faker::Name.name
@@ -54,5 +56,7 @@ password = "password"
 User.create!(name:  name,
     email: email,
     password:              password,
-    password_confirmation: password)
+    password_confirmation: password,
+    activated: true,
+    activated_at: Time.zone.now)
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     password { 'foobar' }
     password_confirmation { 'foobar' }
     admin { true }
+    activated { true }
+    activated_at { Time.zone.now }
 
     factory :other_user do
       name { 'Other User' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,14 @@ FactoryBot.define do
       admin { false }
     end
 
+    factory :non_activated_user do
+      name { 'Non Activated User' }
+      email { 'non_activated@example.com' }
+      admin { false }
+      activated { false }
+      activated_at { nil }
+    end
+
     factory :all_user do
       sequence(:name) { |n| "tester#{n}" }
       sequence(:email) { |n| "tester#{n}@example.com" }

--- a/spec/fixtures/user_mailer/account_activation
+++ b/spec/fixtures/user_mailer/account_activation
@@ -1,0 +1,3 @@
+UserMailer#account_activation
+
+Hi, find me in app/views/user_mailer/account_activation

--- a/spec/fixtures/user_mailer/password_reset
+++ b/spec/fixtures/user_mailer/password_reset
@@ -1,0 +1,3 @@
+UserMailer#password_reset
+
+Hi, find me in app/views/user_mailer/password_reset

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,6 +1,5 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
-
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
   def account_activation
     user = User.first
@@ -12,5 +11,4 @@ class UserMailerPreview < ActionMailer::Preview
   def password_reset
     UserMailer.password_reset
   end
-
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,26 +1,26 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe UserMailer, type: :mailer do
-  describe "account_activation" do
+RSpec.describe UserMailer do
+  describe 'account_activation' do
     let(:user) { create(:user) }
-    let(:mail) { UserMailer.account_activation(user) }
+    let(:mail) { described_class.account_activation(user) }
 
     before do
       user.activation_token = User.new_token
     end
 
-    it "renders the headers" do
-      expect(mail.subject).to eq("アカウントの有効化に関して")
-      expect(mail.to).to eq(["user@example.com"])
-      expect(mail.from).to eq(["tontonka2@gmail.com"])
+    it 'renders the headers' do
+      expect(mail.subject).to eq('アカウントの有効化に関して')
+      expect(mail.to).to eq(['user@example.com'])
+      expect(mail.from).to eq(['noreply@mail.tyakudon.com'])
     end
 
-    it "renders the body" do
+    it 'renders the body' do
       expect(mail.html_part.body.to_s).to match(user.name)
       expect(mail.html_part.body.to_s).to match(user.activation_token)
       expect(mail.html_part.body.to_s).to match(CGI.escape(user.email))
     end
   end
 
-  describe "password_reset"
+  describe 'password_reset'
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  describe "account_activation" do
+    let(:user) { create(:user) }
+    let(:mail) { UserMailer.account_activation(user) }
+
+    before do
+      user.activation_token = User.new_token
+    end
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("アカウントの有効化に関して")
+      expect(mail.to).to eq(["user@example.com"])
+      expect(mail.from).to eq(["tontonka2@gmail.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.html_part.body.to_s).to match(user.name)
+      expect(mail.html_part.body.to_s).to match(user.activation_token)
+      expect(mail.html_part.body.to_s).to match(CGI.escape(user.email))
+    end
+  end
+
+  describe "password_reset"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,6 +85,6 @@ RSpec.describe User do
   end
 
   specify 'authenticated? should return false for a user with nil digest' do
-    expect(user).to_not be_authenticated('')
+    expect(user).to_not be_authenticated(:remember, '')
   end
 end

--- a/spec/requests/account_activations_spec.rb
+++ b/spec/requests/account_activations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "AccountActivations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/account_activations_spec.rb
+++ b/spec/requests/account_activations_spec.rb
@@ -1,42 +1,43 @@
 require 'rails_helper'
 
-RSpec.describe "AccountActivations", type: :request do
-  describe "GET /account_activations/:id/edit #edit" do
+RSpec.describe 'AccountActivations' do
+  describe 'GET /account_activations/:id/edit #edit' do
+    let(:user) { controller.instance_variable_get(:@user) }
+
     before do
       post users_path, params: { user: { name: 'example user',
                                          email: 'test@example.com',
                                          password: 'foobar',
-                                         password_confirmation: 'foobar'} }
-      @user = controller.instance_variable_get('@user')
+                                         password_confirmation: 'foobar' } }
     end
 
     context 'with valid token and email' do
       it 'makes user be activated' do
-        get edit_account_activation_path(@user.activation_token, email: @user.email)
-        @user.reload
-        expect(@user).to be_activated
+        get edit_account_activation_path(user.activation_token, email: user.email)
+        user.reload
+        expect(user).to be_activated
       end
 
       it 'makes user be logged_in' do
-        get edit_account_activation_path(@user.activation_token, email: @user.email)
+        get edit_account_activation_path(user.activation_token, email: user.email)
         expect(is_logged_in?).to be_truthy
       end
 
       it 'redirects to user_path' do
-        get edit_account_activation_path(@user.activation_token, email: @user.email)
-        expect(response).to redirect_to @user
+        get edit_account_activation_path(user.activation_token, email: user.email)
+        expect(response).to redirect_to user
       end
     end
 
     context 'with invalid information' do
       it 'does not make user be activated with invalid token' do
-        get edit_account_activation_path('invalid token', email: @user.email)
-        @user.reload
-        expect(@user).to_not be_activated
+        get edit_account_activation_path('invalid token', email: user.email)
+        user.reload
+        expect(user).to_not be_activated
       end
 
       it 'does not make user be logged_in with invalid email' do
-        get edit_account_activation_path(@user.activation_token, email: 'invalid')
+        get edit_account_activation_path(user.activation_token, email: 'invalid')
         expect(is_logged_in?).to be_falsy
       end
     end

--- a/spec/requests/account_activations_spec.rb
+++ b/spec/requests/account_activations_spec.rb
@@ -1,7 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe "AccountActivations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "GET /account_activations/:id/edit #edit" do
+    before do
+      post users_path, params: { user: { name: 'example user',
+                                         email: 'test@example.com',
+                                         password: 'foobar',
+                                         password_confirmation: 'foobar'} }
+      @user = controller.instance_variable_get('@user')
+    end
+
+    context 'with valid token and email' do
+      it 'makes user be activated' do
+        get edit_account_activation_path(@user.activation_token, email: @user.email)
+        @user.reload
+        expect(@user).to be_activated
+      end
+
+      it 'makes user be logged_in' do
+        get edit_account_activation_path(@user.activation_token, email: @user.email)
+        expect(is_logged_in?).to be_truthy
+      end
+
+      it 'redirects to user_path' do
+        get edit_account_activation_path(@user.activation_token, email: @user.email)
+        expect(response).to redirect_to @user
+      end
+    end
+
+    context 'with invalid information' do
+      it 'does not make user be activated with invalid token' do
+        get edit_account_activation_path('invalid token', email: @user.email)
+        @user.reload
+        expect(@user).to_not be_activated
+      end
+
+      it 'does not make user be logged_in with invalid email' do
+        get edit_account_activation_path(@user.activation_token, email: 'invalid')
+        expect(is_logged_in?).to be_falsy
+      end
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -15,26 +15,69 @@ RSpec.describe 'Users' do
     end
   end
 
-  describe 'POST /users #create' do
-    it 'cannot create account with invalid information' do
-      expect {
-        post users_path, params: { user: { name: '',
-                                           email: 'user@invalid',
-                                           password: 'foo',
-                                           password_confirmation: 'bar' } }
-      }.to_not change(User, :count)
-
-      expect(response).to have_http_status(:unprocessable_entity)
+  describe 'GET /users/:id #show' do
+    context 'with activated user' do
+      it 'shows user page' do
+        activated_user = create(:user)
+        get user_path(activated_user)
+        expect(response.body).to include(activated_user.name)
+      end
     end
 
-    it 'creats account with valid information' do
-      expect {
-        post users_path, params: { user: { name: 'user',
-                                           email: 'user@examle.com',
-                                           password: 'foobar',
-                                           password_confirmation: 'foobar' } }
-        expect(is_logged_in?).to be_truthy
-      }.to change(User, :count).by(1)
+    context 'with non activated user' do
+      it 'redirects to root_path' do
+        non_activated_user = create(:non_activated_user)
+        get user_path(non_activated_user)
+        expect(response).to redirect_to root_path
+      end
+    end
+
+  end
+
+  describe 'POST /users #create' do
+    context 'with invalid information' do
+      it 'does not create an account' do
+        expect {
+          post users_path, params: { user: { name: '',
+                                             email: 'user@invalid',
+                                             password: 'foor',
+                                             password_confirmation: 'bar' } }
+        }.to_not change(User, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'with valid information' do
+      let(:user_params) { { user: { name: 'user',
+                                    email: 'user@examle.com',
+                                    password: 'foobar',
+                                    password_confirmation: 'foobar' } } }
+
+      it 'creats an account' do
+        expect {
+          post users_path, params: user_params
+        }.to change(User, :count).by(1)
+      end
+
+      it 'is still not logged in ' do
+        post users_path, params: user_params
+        expect(is_logged_in?).to be_falsy
+      end
+
+      before do
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it 'sends an email' do
+        post users_path, params: user_params
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+
+      it 'is still not activated' do
+        post users_path, params: user_params
+        expect(User.last).to_not be_activated
+      end
     end
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'Users' do
         expect(response).to redirect_to root_path
       end
     end
-
   end
 
   describe 'POST /users #create' do
@@ -49,10 +48,16 @@ RSpec.describe 'Users' do
     end
 
     context 'with valid information' do
-      let(:user_params) { { user: { name: 'user',
-                                    email: 'user@examle.com',
-                                    password: 'foobar',
-                                    password_confirmation: 'foobar' } } }
+      let(:user_params) do
+        { user: { name: 'user',
+                  email: 'user@examle.com',
+                  password: 'foobar',
+                  password_confirmation: 'foobar' } }
+      end
+
+      before do
+        ActionMailer::Base.deliveries.clear
+      end
 
       it 'creats an account' do
         expect {
@@ -60,13 +65,9 @@ RSpec.describe 'Users' do
         }.to change(User, :count).by(1)
       end
 
-      it 'is still not logged in ' do
+      it 'is still not logged in' do
         post users_path, params: user_params
         expect(is_logged_in?).to be_falsy
-      end
-
-      before do
-        ActionMailer::Base.deliveries.clear
       end
 
       it 'sends an email' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe 'Users' do
       fill_in 'パスワード', with: 'foobar'
       fill_in 'パスワード(確認)', with: 'foobar'
       click_button '登録する'
-      expect(page).to have_content '登録が完了しました'
-      expect(page).to have_content 'もりを'
+      expect(page).to have_content 'メールを確認してアカウントを有効にしてください'
     }.to change(User, :count).by(1)
   end
 
@@ -55,7 +54,7 @@ RSpec.describe 'Users' do
     let!(:non_admin) { create(:other_user) }
 
     before do
-      create_list(:all_user, 30)
+      create_list(:all_user, 15)
     end
 
     context 'with admin' do
@@ -79,6 +78,15 @@ RSpec.describe 'Users' do
         log_in_as(non_admin)
         visit users_path
         expect(page).to_not have_link '削除'
+      end
+
+      it 'does not show non_activated_user' do
+        non_activated_user = create(:non_activated_user)
+        log_in_as(non_admin)
+        visit users_path
+        expect(page).to_not have_link non_activated_user.name, href: user_path(non_activated_user)
+        click_link '次', match: :first
+        expect(page).to_not have_link non_activated_user.name, href: user_path(non_activated_user)
       end
     end
   end


### PR DESCRIPTION
## やったこと
- Mailerの設定
  - 本番ではMailgunを使用できるよう設定
  - アカウントの有効化を促すメイラーを追加
  - 送信メッセージフォーマットを作成
  - Previewの設定
- 有効化トークンが記載されたリンクに反応するAccountActivationコントローラを作成
  - ユーザー有効化用digestを元にtokenを認証
  - ユーザーを有効化する
  - ユーザーをログインさせる
- Usersコントローラ
  - 全てのユーザー表示ページでは有効化されたユーザーのみを表示するよう変更
  - 有効化されていないユーザーページにアクセスしようとするとroot_pathに遷移するよう変更 
- Userモデルの改良
  - activation用にカラムを追加
  - activation_tokenのアクセサを設定
  - authenticated?メソッド: 渡したシンボルに対応して認証できるよう改良
  - create_activation_digestメソッド: Userをcreateする前にアカウント有効化用のdigestを作成する
  - activateメソッド: ユーザーを有効化する(アカウント有効化認証が完了後に使用）
  - send_activation_emailメソッド: アカウント有効化用のメールを送信する
  - down_case_emailメソッド: User.save前にemailの文字列を小文字に変換する
- activated状態をseedsのUserに反映
- activated状態をfactoriesのUserに反映
- ユーザー有効化用のspecを追加

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス