### PR TITLE
パスワードリセット機能を追加

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,7 @@
+class PasswordResetsController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,8 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update]
+
   def new
   end
 
@@ -15,5 +19,43 @@ class PasswordResetsController < ApplicationController
   end
 
   def edit
+  end
+
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, 'を入力してください')
+      render :edit, status: :unprocessable_entity
+    elsif @user.update(user_params)
+      reset_session
+      forget @user
+      @user.update_attribute(:reset_digest, nil)
+      log_in @user
+      redirect_to @user, notice: 'パスワードを更新しました'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  def valid_user
+    unless @user && @user.activated? &&
+           @user.authenticated?(:reset, params[:id])
+      redirect_to root_path, alert: '無効なユーザーによるリクエストです'
+    end
+  end
+
+  def check_expiration
+    if @user.password_reset_expired?
+      redirect_to new_password_reset_path, alert: 'パスワードリセット用URLの有効期限が切れています。'
+    end
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,6 +2,18 @@ class PasswordResetsController < ApplicationController
   def new
   end
 
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      redirect_to root_path, notice: 'メールを確認してパスワードを再設定してください'
+    else
+      flash.now.notice = 'アカウントが見つかりませんでした'
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def edit
   end
 end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,9 +4,8 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: 'アカウントの有効化に関して'
   end
 
-  def password_reset
-    @greeting = 'Hi'
-
-    mail to: 'to@example.org'
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: 'パスワードリセットについて'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,8 +48,7 @@ class User < ApplicationRecord
   end
 
   def activate
-    update_attribute(:activated, true)
-    update_attribute(:activated_at, Time.zone.now)
+    update_columns(activated: true, activated_at: Time.zone.now)
   end
   # rubocop:enable Rails/SkipsModelValidations
 
@@ -59,13 +58,17 @@ class User < ApplicationRecord
 
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attribute(:reset_digest, User.digest(reset_token))
-    update_attribute(:reset_sent_at, Time.zone.now)
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
   end
 
   def send_password_reset_email
     UserMailer.password_reset(self).deliver_now
   end
+
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
+  end
+
   private
 
   def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,24 @@ class User < ApplicationRecord
     remember_digest
   end
 
+  def forget
+    update_attribute(:remember_digest, nil)
+  end
+
+  def forget_reset_digest
+    update_attribute(:reset_digest, nil)
+  end
+
+  def activate
+    update_columns(activated: true, activated_at: Time.zone.now)
+  end
+
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
   def session_token
     remember_digest || remember
   end
@@ -43,22 +61,8 @@ class User < ApplicationRecord
     BCrypt::Password.new(digest).is_password?(token)
   end
 
-  def forget
-    update_attribute(:remember_digest, nil)
-  end
-
-  def activate
-    update_columns(activated: true, activated_at: Time.zone.now)
-  end
-  # rubocop:enable Rails/SkipsModelValidations
-
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
-  end
-
-  def create_reset_digest
-    self.reset_token = User.new_token
-    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
   end
 
   def send_password_reset_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   before_save :downcase_email
   before_create :create_activation_digest
@@ -57,6 +57,15 @@ class User < ApplicationRecord
     UserMailer.account_activation(self).deliver_now
   end
 
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_attribute(:reset_digest, User.digest(reset_token))
+    update_attribute(:reset_sent_at, Time.zone.now)
+  end
+
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
   private
 
   def downcase_email

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,9 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<h1>パスワード再設定</h1>
+<%= bootstrap_form_with model: @user, url: password_reset_path(params[:id]) do |f|%>
+  <%= hidden_field_tag :email, @user.email %>
+  <%= f.password_field :password, label: "パスワード" , help: '6文字以上入力してね' %>
+  <%= f.password_field :password_confirmation, label: "パスワード(確認)" %>
+  <div class="d-grid">
+    <%= f.submit 'パスワードを再設定する' %>
+  </div>
+<% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#new</h1>
+<p>Find me in app/views/password_resets/new.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,2 +1,9 @@
-<h1>PasswordResets#new</h1>
-<p>Find me in app/views/password_resets/new.html.erb</p>
+<h1>パスワード再設定</h1>
+<div class="col-md-6">
+  <%= bootstrap_form_with url: password_resets_path, scope: :password_reset do |f|%>
+    <%= f.email_field :email, label: "メールアドレス" %>
+    <div class="d-grid">
+      <%= f.submit "パスワードを再設定する" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,6 +9,7 @@
     </div>
   <% end %>
   <div class="mt-1 mb-3">
-    <%= link_to 'アカウントをお持ちでない方はこちら', new_user_path %>
+    <p><%= link_to 'アカウントをお持ちでない方はこちら', new_user_path %></p>
+    <p><%= link_to 'パスワードをお忘れの方はこちら', new_password_rest_path %></p>
   </div>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,6 +10,6 @@
   <% end %>
   <div class="mt-1 mb-3">
     <p><%= link_to 'アカウントをお持ちでない方はこちら', new_user_path %></p>
-    <p><%= link_to 'パスワードをお忘れの方はこちら', new_password_rest_path %></p>
+    <p><%= link_to 'パスワードをお忘れの方はこちら', new_password_reset_path %></p>
   </div>
 </div>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,6 @@
-<h1>User#password_reset</h1>
-
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
-</p>
+<h1>パスワードリセット</h1>
+<p>下記のリンクをクリックして、パスワードをリセットしてください。</p>
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+<p>このリンクは２時間で失効します。</p>
+<p>パスワードのリセットリクエストを送っていない場合は、このEメールを無視してください。
+現在のパスワード設定のままご利用いただけます。</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,5 @@
-User#password_reset
-
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+下記のリンクをクリックして、パスワードをリセットしてください。
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+このリンクは２時間で失効します。
+パスワードのリセットリクエストを送っていない場合は、このEメールを無視してください。
+現在のパスワード設定のままご利用いただけます。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
   end
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20230709205638_add_reset_to_users.rb
+++ b/db/migrate/20230709205638_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_05_092225) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_09_205638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_05_092225) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -9,6 +9,8 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -22,5 +22,23 @@ RSpec.describe UserMailer do
     end
   end
 
-  describe 'password_reset'
+  describe 'password_reset' do
+    let(:user) { create(:user) }
+    let(:mail) { described_class.password_reset(user) }
+
+    before do
+      user.reset_token = User.new_token
+    end
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('パスワードリセットについて')
+      expect(mail.to).to eq(['user@example.com'])
+      expect(mail.from).to eq(['noreply@mail.tyakudon.com'])
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body.to_s).to match(user.reset_token)
+      expect(mail.html_part.body.to_s).to match(CGI.escape(user.email))
+    end
+  end
 end

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'PasswordResets', type: :request do
+RSpec.describe 'PasswordResets' do
   describe 'POST /password_resets/ #post' do
     let(:user) { create(:user) }
     let(:user_params) { { password_reset: { email: user.email } } }
@@ -41,7 +41,7 @@ RSpec.describe 'PasswordResets', type: :request do
       it 'has hidden email field' do
         post password_resets_path, params: { password_reset: { email: create(:user).email } }
         get edit_password_reset_path(user.reset_token, email: user.email)
-        expect(response.body).to include "type=\"hidden\" name=\"email\" id=\"email\" value=\"#{user.email}\"";
+        expect(response.body).to include "type=\"hidden\" name=\"email\" id=\"email\" value=\"#{user.email}\""
       end
     end
 
@@ -50,11 +50,13 @@ RSpec.describe 'PasswordResets', type: :request do
         post password_resets_path, params: { password_reset: { email: create(:user).email } }
       end
 
+      # rubocop:disable Rails/SkipsModelValidations
       it 'redirects to root_path when user does not activated' do
         user.toggle!(:activated)
         get edit_password_reset_path(user.reset_token, email: user.email)
         expect(response).to redirect_to root_path
       end
+      # rubocop:enable Rails/SkipsModelValidations
 
       it 'redirects to root_path with invalid token' do
         get edit_password_reset_path('invalid token', email: user.email)
@@ -90,7 +92,6 @@ RSpec.describe 'PasswordResets', type: :request do
     context 'with valid password' do
       let(:user_params) { { user: { password: 'foobar', password_confirmation: 'foobar' } } }
 
-
       it 'updates password' do
         patch password_reset_path(user.reset_token, email: user.email), params: user_params
         expect(user.password_digest).to_not eq user.reload.password_digest
@@ -114,12 +115,14 @@ RSpec.describe 'PasswordResets', type: :request do
 
     context 'with invalid password' do
       it 'does not update password with blank password' do
-        patch password_reset_path(user.reset_token, email: user.email), params: { user: { password: '', password_confirmation: '' } }
+        patch password_reset_path(user.reset_token, email: user.email),
+              params: { user: { password: '', password_confirmation: '' } }
         expect(response).to have_http_status :unprocessable_entity
       end
 
       it 'does not update password with invalid password' do
-        patch password_reset_path(user.reset_token, email: user.email), params: { user: { password: 'foo', password_confirmation: 'bar' } }
+        patch password_reset_path(user.reset_token, email: user.email),
+              params: { user: { password: 'foo', password_confirmation: 'bar' } }
         expect(response).to have_http_status :unprocessable_entity
       end
     end

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe 'PasswordResets', type: :request do
+  describe 'POST /password_resets/ #post' do
+    let(:user) { create(:user) }
+    let(:user_params) { { password_reset: { email: user.email } } }
+
+    context 'when the account exits' do
+      before do
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it 'changes reset digest' do
+        post password_resets_path, params: user_params
+        expect(user.reset_digest).to_not eq user.reload.reset_digest
+      end
+
+      it 'sends an email' do
+        post password_resets_path, params: user_params
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+
+      it 'redirects to root_path' do
+        post password_resets_path, params: user_params
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context 'when the account is not found' do
+      it 'return unprocessable_entity' do
+        post password_resets_path, params: { password_reset: { email: 'invalid' } }
+        expect(response).to have_http_status :unprocessable_entity
+      end
+    end
+  end
+
+  describe 'GET /password_resets/:id/edit #edit' do
+    let(:user) { controller.instance_variable_get(:@user) }
+
+    context 'with valid token and email' do
+      it 'has hidden email field' do
+        post password_resets_path, params: { password_reset: { email: create(:user).email } }
+        get edit_password_reset_path(user.reset_token, email: user.email)
+        expect(response.body).to include "type=\"hidden\" name=\"email\" id=\"email\" value=\"#{user.email}\"";
+      end
+    end
+
+    context 'with invalid information' do
+      before do
+        post password_resets_path, params: { password_reset: { email: create(:user).email } }
+      end
+
+      it 'redirects to root_path when user does not activated' do
+        user.toggle!(:activated)
+        get edit_password_reset_path(user.reset_token, email: user.email)
+        expect(response).to redirect_to root_path
+      end
+
+      it 'redirects to root_path with invalid token' do
+        get edit_password_reset_path('invalid token', email: user.email)
+        expect(response).to redirect_to root_path
+      end
+
+      context 'when reset_sent_at is expired' do
+        before do
+          user.update(reset_sent_at: 3.hours.ago)
+        end
+
+        it 'redirects to new_password_reset_path' do
+          get edit_password_reset_path(user.reset_token, email: user.email)
+          expect(response).to redirect_to new_password_reset_path
+        end
+
+        it 'shows flash suggesting expired' do
+          get edit_password_reset_path(user.reset_token, email: user.email)
+          follow_redirect!
+          expect(response.body).to include 'パスワードリセット用URLの有効期限が切れています'
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /password_resets/:id #update' do
+    let(:user) { controller.instance_variable_get(:@user) }
+
+    before do
+      post password_resets_path, params: { password_reset: { email: create(:user).email } }
+    end
+
+    context 'with valid password' do
+      let(:user_params) { { user: { password: 'foobar', password_confirmation: 'foobar' } } }
+
+
+      it 'updates password' do
+        patch password_reset_path(user.reset_token, email: user.email), params: user_params
+        expect(user.password_digest).to_not eq user.reload.password_digest
+      end
+
+      it 'makes user be logged in' do
+        patch password_reset_path(user.reset_token, email: user.email), params: user_params
+        expect(is_logged_in?).to be_truthy
+      end
+
+      it 'redirects to user_path' do
+        patch password_reset_path(user.reset_token, email: user.email), params: user_params
+        expect(response).to redirect_to user_path(user)
+      end
+
+      it 'updates reset_digest to nil' do
+        patch password_reset_path(user.reset_token, email: user.email), params: user_params
+        expect(user.reload.reset_digest).to be_nil
+      end
+    end
+
+    context 'with invalid password' do
+      it 'does not update password with blank password' do
+        patch password_reset_path(user.reset_token, email: user.email), params: { user: { password: '', password_confirmation: '' } }
+        expect(response).to have_http_status :unprocessable_entity
+      end
+
+      it 'does not update password with invalid password' do
+        patch password_reset_path(user.reset_token, email: user.email), params: { user: { password: 'foo', password_confirmation: 'bar' } }
+        expect(response).to have_http_status :unprocessable_entity
+      end
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
- パスワードリセット機能を追加
  - 仕様
    - パスワードリセットしたい場合に専用のフォームからemailを入力して投稿
    - 送付されたemail内のリセット用リンクをクリックすると変更用フォームが出現（リンク有効期限は２時間）
    - ユーザー状態と入力されたパスワードが有効な場合にパスワードをリセット
  - Userモデルにreset_digestとreset_sent_atを追加
  - リセット用コントローラと入力用フォームを追加
  - リセット用のリンクを送付するようメーラーを改修
  - パスワードリセット機能検証用のspecを追加

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス