### PR TITLE
バグ修正によるrecordsコントローラの改良

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,8 @@ class ApplicationController < ActionController::Base
     flash.alert = 'ログインしてください'
     redirect_to login_url, status: :see_other
   end
+
+  def disable_connect_button
+    @show_connect_button = false
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   before_action :logged_in_user, only: %i[search]
+  before_action :disable_connect_button, only: %i[search]
 
   def index
     @search = RamenShop.ransack(params[:q])

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -2,6 +2,7 @@ class RecordsController < ApplicationController
   before_action :logged_in_user, only: %i[new edit create measure update]
   before_action :set_record, only: %i[show measure edit update]
   before_action :set_ramen_shop, except: %i[new create]
+  before_action :disable_connect_button, only: %i[measure]
 
   def show
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,8 @@ module ApplicationHelper
   def turbo_stream_flash
     turbo_stream.update 'flash', partial: 'flash'
   end
+
+  def show_connect_button?
+    defined?(@show_connect_button) ? @show_connect_button : true
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,9 @@ module ApplicationHelper
     turbo_stream.update 'flash', partial: 'flash'
   end
 
+  # rubocop:disable Rails/HelperInstanceVariable
   def show_connect_button?
     defined?(@show_connect_button) ? @show_connect_button : true
   end
+  # rubocop:enable Rails/HelperInstanceVariable
 end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -2,4 +2,10 @@ module RecordsHelper
   def shop_or_user(record, name)
     record.send(name).name
   end
+
+  def remember_record
+  end
+
+  def forget_record
+  end
 end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -3,9 +3,11 @@ module RecordsHelper
     record.send(name).name
   end
 
-  def remember_record
+  def remember_record?
+    cookies[:record_id]
   end
 
-  def forget_record
+  def fetch_record_id
+    cookies.encrypted[:record_id]
   end
 end

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -35,4 +35,8 @@ export default class extends Controller {
   end() {
     clearInterval(this.timer);
   }
+
+  disconnect() {
+    clearInterval(this.timer);
+  }
 }

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,8 +2,8 @@
   <% if logged_in? && show_connect_button? %>
     <div class="p-1 fixed-bottom">
       <div class="d-grid col-sm-6 mx-auto">
-        <% if cookies[:record_id] %>
-          <%= link_to '接続中レコード', measure_record_path(cookies.encrypted[:record_id]), class: "btn btn-warning" %>
+        <% if remember_record? %>
+          <%= link_to '接続中レコード', measure_record_path(fetch_record_id), class: "btn btn-warning" %>
         <% else %>
           <%= link_to '現在地からセツゾク', search_path, class: "btn btn-warning" %>
         <%  end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,15 @@
 <footer class="bg-light text-center text-lg-start">
+  <% if logged_in? && show_connect_button? %>
+    <div class="p-1 fixed-bottom">
+      <div class="d-grid col-sm-6 mx-auto">
+        <% if cookies[:record_id] %>
+          <%= link_to '接続中レコード', measure_record_path(cookies.encrypted[:record_id]), class: "btn btn-warning" %>
+        <% else %>
+          <%= link_to '現在地からセツゾク', search_path, class: "btn btn-warning" %>
+        <%  end %>
+      </div>
+    </div>
+  <% end %>
   <div class="text-center p-1 pb-5" style="background-color: rgba(0, 0, 0, 0.2);">
     © 2023 moriw0
   </div>

--- a/app/views/ramen_shops/index.html.erb
+++ b/app/views/ramen_shops/index.html.erb
@@ -27,10 +27,3 @@
     </div>
   </div>
 </div>
-<% if logged_in? %>
-  <div class="p-1 fixed-bottom">
-    <div class="d-grid col-sm-6 mx-auto">
-      <%= link_to '現在地からセツゾク', search_path, class: "btn btn-warning" %>
-    </div>
-  </div>
-<% end %>

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     wait_time { 600 }
     comment { 'いただきます！' }
     ramen_shop
-    created_at { 1.minute.ago }
     user
 
     factory :oldest do

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -83,11 +83,11 @@ RSpec.describe 'Records' do
         end
       end
 
-      context 'the record.ended_at? is true' do
+      context 'when the record.ended_at? is true' do
         it 'redirects to root_path' do
           log_in_as(user)
           do_request
-          redirect_to root_path
+          expect(response).to redirect_to root_path
         end
       end
     end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -2,22 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Records' do
   let(:ramen_shop) { create(:ramen_shop) }
-  let(:user) { create(:all_user) }
-  let(:record) { create(:record) }
-  let(:record_params) do
-    { record: {
-      ramen_shop_id: ramen_shop.id,
-      user_id: user.id,
-      started_at: 1.minute.ago,
-      ended_at: Time.zone.now,
-      comment: 'ちゃくどん',
-      line_statuses_attributes: [
-        line_number: 1,
-        line_type: 'inside_the_store',
-        comment: '並ぶぞ'
-      ]
-    } }
-  end
+  let(:user) { create(:user) }
+  let(:record) { create(:record, ramen_shop: ramen_shop, user: user) }
 
   shared_examples 'when not logged in' do
     it 'redirects to login_path' do
@@ -39,8 +25,20 @@ RSpec.describe 'Records' do
   end
 
   describe 'POST /ramen_shops/:ramen_shop_id/records #create' do
-    let(:do_request) { post ramen_shop_records_path(ramen_shop), params: record_params, as: :turbo_stream }
+    let(:do_request) { post ramen_shop_records_path(ramen_shop), params: record_params_without_record }
     let(:record) { controller.instance_variable_get(:@record) }
+    let(:record_params_without_record) do
+      { record: {
+        ramen_shop_id: ramen_shop.id,
+        user_id: user.id,
+        started_at: nil,
+        line_statuses_attributes: [
+          line_number: 1,
+          line_type: 'inside_the_store',
+          comment: '並ぶぞ'
+        ]
+      } }
+    end
 
     it_behaves_like 'when not logged in'
 
@@ -56,8 +54,8 @@ RSpec.describe 'Records' do
 
       context 'with invalid information' do
         it 'shows validation errors' do
-          record_params[:record][:line_statuses_attributes][0][:line_number] = -1
-          post ramen_shop_records_path(ramen_shop), params: record_params, as: :turbo_stream
+          record_params_without_record[:record][:line_statuses_attributes][0][:line_number] = -1
+          post ramen_shop_records_path(ramen_shop), params: record_params_without_record, as: :turbo_stream
           expect(response.body).to include 'は0以上の値にしてください'
         end
       end
@@ -65,27 +63,42 @@ RSpec.describe 'Records' do
   end
 
   describe 'GET /records/:id/edit #edit' do
-    let(:do_request) { get edit_record_path(record), as: :turbo_stream }
+    let(:do_request) { get edit_record_path(record) }
 
     it_behaves_like 'when not logged in'
   end
 
   describe 'GET /records/:id/measure #measure' do
-    let(:do_request) { get measure_record_path(record), as: :turbo_stream }
+    let(:do_request) { get measure_record_path(record) }
 
     it_behaves_like 'when not logged in'
 
-    it 'updates started_at when logged in' do
-      record.update(started_at: nil)
-      log_in_as(user)
-      do_request
-      expect(record.reload.started_at).to_not be_nil
+    context 'when logged in' do
+      context 'when a record is not remembered' do
+        it 'updates started_at when logged in' do
+          record.update(started_at: nil, ended_at: nil)
+          log_in_as(user)
+          do_request
+          expect(record.reload.started_at).to_not be_nil
+        end
+      end
+
+      context 'the record.ended_at? is true' do
+        it 'redirects to root_path' do
+          log_in_as(user)
+          do_request
+          redirect_to root_path
+        end
+      end
     end
   end
 
   describe 'PATCH /records/:id #update' do
-    let(:do_request) { patch record_path(record), params: record_params, as: :turbo_stream }
+    let(:do_request) { patch record_path(record), params: record_params }
     let(:instance_record) { controller.instance_variable_get(:@record) }
+    let(:record_params) do
+      { record: { started_at: 1.minute.ago } }
+    end
 
     it_behaves_like 'when not logged in'
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,7 +3,7 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
 
-  config.before(:each, type: :system, js: true) do
+  config.before(:each, js: true, type: :system) do
     driven_by :selenium_chrome
   end
 end

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Records", type: :system, js: true do
+RSpec.describe 'Records', js: true do
   let(:user) { create(:user) }
   let!(:ramen_shop) { create(:ramen_shop) }
 
@@ -8,14 +8,14 @@ RSpec.describe "Records", type: :system, js: true do
     log_in_as(user)
   end
 
-  scenario "user creates a record of the nearby ramen shop" do
-    click_link "現在地からセツゾク"
+  scenario 'user creates a record of the nearby ramen shop' do
+    click_link '現在地からセツゾク'
 
     # searchページ
     expect(page).to_not have_link '現在地からセツゾク'
-    expect(page).to have_css ".loading-spinner"
-    expect(page).to have_css '#map', visible: true, wait: 15
-    expect(page).to_not have_css ".loading-spinner"
+    expect(page).to have_css '.loading-spinner'
+    expect(page).to have_css '#map', visible: :visible, wait: 15
+    expect(page).to_not have_css '.loading-spinner'
 
     # 接続するラーメン店を選択して最初の待ち行列情報を入力
     click_link ramen_shop.name, href: new_ramen_shop_record_path(ramen_shop)

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe "Records", type: :system, js: true do
+  let(:user) { create(:user) }
+  let!(:ramen_shop) { create(:ramen_shop) }
+
+  before do
+    log_in_as(user)
+  end
+
+  scenario "user creates a record of the nearby ramen shop" do
+    click_link "現在地からセツゾク"
+
+    # searchページ
+    expect(page).to_not have_link '現在地からセツゾク'
+    expect(page).to have_css ".loading-spinner"
+    expect(page).to have_css '#map', visible: true, wait: 15
+    expect(page).to_not have_css ".loading-spinner"
+
+    # 接続するラーメン店を選択して最初の待ち行列情報を入力
+    click_link ramen_shop.name, href: new_ramen_shop_record_path(ramen_shop)
+    fill_in '待ち行列数', with: 5
+    choose '店内'
+    fill_in 'ひとこと', with: '並ぶぞ'
+    click_button '登録する'
+
+    # measureページ
+    expect(page).to have_content 'セツゾクしました'
+    expect(page).to have_content ramen_shop.name
+    expect(page).to have_content '00:00:01', wait: 1
+    expect(page).to_not have_link '現在地からセツゾク'
+
+    # measureページを一時離脱して再接続
+    visit root_path
+    record = Record.last
+    click_link '接続中レコード', href: measure_record_path(record)
+    expect(page).to have_content '再セツゾクしました'
+    expect(page).to have_content '00:00:03', wait: 3
+
+    # 待ち行列状況を追加登録
+    click_link '追加登録'
+    fill_in '待ち行列数', with: 1
+    choose '店内'
+    fill_in 'ひとこと', with: 'もう少し'
+    click_button '登録する'
+    sleep(1) # 暫定対策: responseを待ってからmodalを強制的に閉じる
+    find('button[data-bs-dismiss="modal"]').click
+
+    # measureページに追加登録情報が反映されている
+    expect(page).to have_content '行列の様子を登録しました'
+    expect(page).to have_content 'もう少し'
+    expect(page).to have_content '00:00:05', wait: 2
+    click_button 'ちゃくどん'
+
+    # 着丼後のRecordページ
+    expect(page).to have_content 'ちゃくどんレコードを登録しました'
+    expect(page).to have_content '00:00:05'
+
+    # ブラウザバックするとmeasureページでなくroot_pathへリダイレクト
+    go_back
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_link '現在地からセツゾク'
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Logins' do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
 
   scenario 'login with valid email and invalid password' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Users' do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
 
   scenario 'user creates an account with valid information' do


### PR DESCRIPTION
## やったこと
- issues改善のためmeasureアクションを改良
  - 行列に接続したらレコードIDをcookiesに保管（1日以内の行列に対応）
  - cookiesにrecord_idがあれば、時間計測を再開 
    - fixed #32 
  - 既に時間計測したレコードにアクセスするとroot_pathへリダイレクト 
    - fixed #42 
- 各ページへ行列接続用リンクを掲載
  - 既に行列接続中の場合はmeasure_record_path(record)
  - そうでない場合はsearch_path
  - homeコントローラのsearchアクション、recordsコントローラのmeasureアクションではリンクを表示しない
    -  show_connect_button?とdisable_connect_buttonヘルパーを実装
- Recordスペック
  - 接続から着丼までの一連の様子を模擬したシステムスペックを追加
  - 冗長な記述を見直してリクエストスペックを改良
- その他
  - timerインターバルはunload時にクリアするようにした

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス