### PR TITLE
Favorite

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -181,3 +181,20 @@ aside {
     border-bottom: 1px solid #eeeeee;
   }
 }
+.stats {
+  overflow: auto;
+  margin-bottom: 10px;
+  padding: 0;
+  a {
+    float: left;
+    padding: 0 10px;
+    color: gray;
+    &:first-child {
+      padding-left: 0;
+      border: 0;
+    }
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,21 @@
+class FavoritesController < ApplicationController
+  before_action :logged_in_user
+
+  def create
+    @ramen_shop = RamenShop.find(params[:ramen_shop_id])
+    current_user.add_favorite(@ramen_shop)
+    respond_to do |format|
+      format.html { redirect_to @ramen_shop }
+      format.turbo_stream
+    end
+  end
+
+  def destroy
+    @ramen_shop = Favorite.find(params[:id]).ramen_shop
+    current_user.remove_favorite(@ramen_shop)
+    respond_to do |format|
+      format.html { redirect_to @ramen_shop, status: :see_other }
+      format.turbo_stream
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: %i[index edit update destroy]
+  before_action :logged_in_user, only: %i[index edit update destroy favorite_shops]
   before_action :correct_user, only: %i[edit update]
   before_action :admin_user, only: :destroy
 
@@ -43,6 +43,11 @@ class UsersController < ApplicationController
   def destroy
     User.find(params[:id]).destroy
     redirect_to users_url, status: :see_other, notice: 'ユーザーを削除しました'
+  end
+
+  def favorite_shops
+    @user  = User.find(params[:id])
+    @ramen_shops = @user.favorite_shops.page(params[:page])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
   end
 
   def favorite_shops
-    @user  = User.find(params[:id])
+    @user = User.find(params[:id])
     @ramen_shops = @user.favorite_shops.page(params[:page])
   end
 

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,4 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :ramen_shop
+end

--- a/app/models/ramen_shop.rb
+++ b/app/models/ramen_shop.rb
@@ -1,9 +1,16 @@
 class RamenShop < ApplicationRecord
   geocoded_by :address
   after_validation :geocode
+
   has_many :records, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_users, through: :favorites, source: :user
 
   def self.ransackable_attributes(_auth_object = nil)
     ['name']
+  end
+
+  def favorited_by?(user)
+    favorite_users.include?(user)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   attr_accessor :remember_token, :activation_token, :reset_token
 
   has_many :records, dependent: :restrict_with_exception
+  has_many :favorites, dependent: :restrict_with_exception
+  has_many :favorite_shops, through: :favorites, source: :ramen_shop
+
   before_save :downcase_email
   before_create :create_activation_digest
 
@@ -72,6 +75,18 @@ class User < ApplicationRecord
 
   def password_reset_expired?
     reset_sent_at < 2.hours.ago
+  end
+
+  def favorites?(shop)
+    favorite_shops.include?(shop)
+  end
+
+  def add_favorite(shop)
+    favorite_shops << shop unless favorites?(shop)
+  end
+
+  def remove_favorite(shop)
+    favorite_shops.delete(shop) if favorites?(shop)
   end
 
   private

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "favorite_form" do %>
+  <%= render partial: "ramen_shops/remove_favorite" %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "favorite_form" do %>
+  <%= render partial: "ramen_shops/add_favorite" %>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,7 +8,7 @@
       <div class="navbar-nav">
         <% if logged_in? %>
           <%= link_to "プロフィール", current_user, class: 'nav-link' %>
-          <%= link_to "お気に入り", '#', class: 'nav-link' %>
+          <%= link_to "お気に入り", favorites_by_user_path(current_user), class: 'nav-link' %>
           <%= link_to "ログアウト", logout_path, data: { "turbo-method": :delete }, class: 'nav-link' %>
         <% else %>
           <%= link_to "ログイン", login_path, class: "nav-link" %>

--- a/app/views/ramen_shops/_add_favorite.html.erb
+++ b/app/views/ramen_shops/_add_favorite.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.favorites.build) do |f| %>
+  <div><%= hidden_field_tag :ramen_shop_id, @ramen_shop.id %></div>
+  <%= f.submit "お気に入り追加", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/ramen_shops/_favorite_form.html.erb
+++ b/app/views/ramen_shops/_favorite_form.html.erb
@@ -1,0 +1,7 @@
+<div id="favorite_form">
+  <% if current_user.favorites?(@ramen_shop) %>
+    <%= render 'remove_favorite' %>
+  <% else %>
+    <%= render 'add_favorite' %>
+  <% end %>
+</div>

--- a/app/views/ramen_shops/_remove_favorite.html.erb
+++ b/app/views/ramen_shops/_remove_favorite.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.favorites.find_by(ramen_shop: @ramen_shop),
+              html: { method: :delete }) do |f| %>
+  <%= f.submit "お気に入り解除", class: "btn btn-link" %>
+<% end %>

--- a/app/views/ramen_shops/show.html.erb
+++ b/app/views/ramen_shops/show.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= render 'favorite_form' if logged_in? %>
   <h2 class="my-4"><%= @ramen_shop.name %></h2>
   <p class="mb-4"><%= @ramen_shop.address %></p>
   <div class="my-3 p-3 bg-body rounded shadow-sm">

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,0 +1,9 @@
+<% @user ||= current_user %>
+<div class="stats">
+  <%= link_to favorites_by_user_path(@user) do %>
+    お気に入り店
+    <strong id="favorite_shops" class="stat">
+      <%= @user.favorite_shops.count %>
+    </strong>
+  <% end %>
+</div>

--- a/app/views/users/favorite_shops.html.erb
+++ b/app/views/users/favorite_shops.html.erb
@@ -1,0 +1,24 @@
+<aside class="col-md-4">
+  <section class="user_info">
+    <h1>
+      <%= gravatar_for @user %>
+      <%= @user.name %>
+    </h1>
+  </section>
+  <section class="stats">
+    <%= render 'shared/stats' %>
+  </section>
+  <p><%= link_to 'ユーザー情報を編集する', edit_user_path(@user) if current_user?(@user) %></p>
+  <p><%= link_to 'すべてのユーザーをみる', users_path %></p>
+</aside>
+<div class="col-md-8">
+  <% if @ramen_shops.any? %>
+    <div class="my-3 p-3 bg-body rounded shadow-sm">
+    <h6 class="border-bottom pb-2 mb-0"><%= tag.span("お気に入り店 #{@user.favorite_shops.count}") %></h6>
+    <%= render @ramen_shops %>
+    <div class="d-flex justify-content-end mt-3">
+      <%= paginate @ramen_shops %>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,6 +5,9 @@
       <%= @user.name %>
     </h1>
   </section>
+  <section class="stats">
+    <%= render 'shared/stats' %>
+  </section>
   <p><%= link_to 'ユーザー情報を編集する', edit_user_path(@user) if current_user?(@user) %></p>
   <p><%= link_to 'すべてのユーザーをみる', users_path %></p>
 </aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
       resources :line_statuses
     end
   end
-  resources :users
+  resources :users do
+      get 'favorite_shops', on: :member, as: :favorites_by
+  end
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
+  resources :favorites, only: [:create, :destroy]
 end

--- a/db/fixtures/development/sample_favorite.rb
+++ b/db/fixtures/development/sample_favorite.rb
@@ -1,0 +1,26 @@
+ramen_shops = RamenShop.take(20)
+
+user = User.first
+user_favorite_shops = ramen_shops[0..14]
+
+id = 0
+favorites = user_favorite_shops.map do |shop|
+  {
+    id: id += 1,
+    user: user,
+    ramen_shop: shop,
+  }
+end
+
+other_user = User.second
+other_user_favorite_shops = ramen_shops[5..19]
+
+favorites += other_user_favorite_shops.map do |shop|
+  {
+    id: id += 1,
+    user: other_user,
+    ramen_shop: shop,
+  }
+end
+
+Favorite.seed(:id, favorites)

--- a/db/fixtures/development/sample_line_status.rb
+++ b/db/fixtures/development/sample_line_status.rb
@@ -7,32 +7,34 @@ records.each do |record|
   started_at = record[:started_at]
   ended_at = record[:ended_at]
 
-  line_statuses += [
-    {
-      id: id + 1,
-      record: record,
-      line_number: 10,
-      line_type: "outside_the_store",
-      comment: "長くなりそうだ",
-      created_at: started_at
-    },
-    {
-      id: id + 2,
-      record: record,
-      line_number: 2,
-      line_type: "outside_the_store",
-      comment: "もうすぐ店内",
-      created_at: started_at + (ended_at - started_at) / 2
-    },
-    {
-      id: id + 3,
-      record: record,
-      line_number: 2,
-      line_type: "inside_the_store",
-      comment: "あと少し",
-      created_at: ended_at
-    }
-  ]
+  if started_at && ended_at
+    line_statuses += [
+      {
+        id: id + 1,
+        record: record,
+        line_number: 10,
+        line_type: "outside_the_store",
+        comment: "長くなりそうだ",
+        created_at: started_at
+      },
+      {
+        id: id + 2,
+        record: record,
+        line_number: 2,
+        line_type: "outside_the_store",
+        comment: "もうすぐ店内",
+        created_at: started_at + (ended_at - started_at) / 2
+      },
+      {
+        id: id + 3,
+        record: record,
+        line_number: 2,
+        line_type: "inside_the_store",
+        comment: "あと少し",
+        created_at: ended_at
+      }
+    ]
+  end
 
   id += 3
 end

--- a/db/migrate/20230724023236_create_favorites.rb
+++ b/db/migrate/20230724023236_create_favorites.rb
@@ -1,0 +1,11 @@
+class CreateFavorites < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :ramen_shop, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :favorites, [:user_id, :ramen_shop_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_12_093544) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_24_023236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "ramen_shop_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ramen_shop_id"], name: "index_favorites_on_ramen_shop_id"
+    t.index ["user_id", "ramen_shop_id"], name: "index_favorites_on_user_id_and_ramen_shop_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
 
   create_table "line_statuses", force: :cascade do |t|
     t.bigint "record_id", null: false
@@ -63,6 +73,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_12_093544) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "favorites", "ramen_shops"
+  add_foreign_key "favorites", "users"
   add_foreign_key "line_statuses", "records"
   add_foreign_key "records", "ramen_shops"
   add_foreign_key "records", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 SeedFu.seed(nil, /load_master_data/)
 SeedFu.seed(nil, /sample_user/) if ['development', 'test'].include? Rails.env
+SeedFu.seed(nil, /sample_favorite/) if ['development', 'test'].include? Rails.env
 SeedFu.seed(nil, /sample_record/) if ['development', 'test'].include? Rails.env
 SeedFu.seed(nil, /sample_line_status/) if ['development', 'test'].include? Rails.env

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :favorite do
-    user { nil }
-    ramen_shop { nil }
+    user
+    ramen_shop
   end
 end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user { nil }
+    ramen_shop { nil }
+  end
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Favorite, type: :model do
+RSpec.describe Favorite do
   let(:user) { create(:user) }
   let(:ramen_shop) { create(:ramen_shop) }
 
@@ -16,7 +16,7 @@ RSpec.describe Favorite, type: :model do
   end
 
   it 'is invalid without user' do
-    favorite = Favorite.new(ramen_shop: ramen_shop, user: nil)
+    favorite = described_class.new(ramen_shop: ramen_shop, user: nil)
     favorite.valid?
     expect(favorite.errors[:user]).to include 'を入力してください'
   end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,5 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Favorite, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:ramen_shop) { create(:ramen_shop) }
+
+  it 'is valid with user and ramen_shop' do
+    favorite = user.favorites.build(ramen_shop: ramen_shop)
+    expect(favorite).to be_valid
+  end
+
+  it 'is invalid without ramen_shop' do
+    favorite = user.favorites.build(ramen_shop: nil)
+    favorite.valid?
+    expect(favorite.errors[:ramen_shop]).to include 'を入力してください'
+  end
+
+  it 'is invalid without user' do
+    favorite = Favorite.new(ramen_shop: ramen_shop, user: nil)
+    favorite.valid?
+    expect(favorite.errors[:user]).to include 'を入力してください'
+  end
 end

--- a/spec/models/ramen_shop_spec.rb
+++ b/spec/models/ramen_shop_spec.rb
@@ -20,6 +20,6 @@ RSpec.describe RamenShop do
     user = create(:user)
     ramen_shop = create(:ramen_shop)
     user.add_favorite(ramen_shop)
-    expect(ramen_shop.favorited_by?(user)).to be_truthy
+    expect(ramen_shop).to be_favorited_by(user)
   end
 end

--- a/spec/models/ramen_shop_spec.rb
+++ b/spec/models/ramen_shop_spec.rb
@@ -15,4 +15,11 @@ RSpec.describe RamenShop do
     ramen_shop = create(:ramen_shop)
     expect(ramen_shop).to be_valid
   end
+
+  it 'returns true when favorited by the shop' do
+    user = create(:user)
+    ramen_shop = create(:ramen_shop)
+    user.add_favorite(ramen_shop)
+    expect(ramen_shop.favorited_by?(user)).to be_truthy
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,11 +95,11 @@ RSpec.describe User do
     expect { user.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
   end
 
-  it "adds favorite and removes favorite " do
-    expect(user.favorites?(ramen_shop)).to be_falsey
+  it 'adds favorite and removes favorite' do
+    expect(user).to_not be_favorites(ramen_shop)
     user.add_favorite(ramen_shop)
-    expect(user.favorites?(ramen_shop)).to be_truthy
+    expect(user).to be_favorites(ramen_shop)
     user.remove_favorite(ramen_shop)
-    expect(user.favorites?(ramen_shop)).to be_falsey
+    expect(user).to_not be_favorites(ramen_shop)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User do
   let(:user) { build(:user) }
+  let(:ramen_shop) { create(:ramen_shop) }
 
   it 'is valid with name and email' do
     new_user = described_class.new(
@@ -92,5 +93,13 @@ RSpec.describe User do
     user = create(:user)
     create(:record, user: user)
     expect { user.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+  end
+
+  it "adds favorite and removes favorite " do
+    expect(user.favorites?(ramen_shop)).to be_falsey
+    user.add_favorite(ramen_shop)
+    expect(user.favorites?(ramen_shop)).to be_truthy
+    user.remove_favorite(ramen_shop)
+    expect(user.favorites?(ramen_shop)).to be_falsey
   end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Favorites", type: :request do
+RSpec.describe 'Favorites' do
   let(:user) { create(:user) }
   let(:ramen_shop) { create(:ramen_shop) }
 
@@ -54,7 +54,7 @@ RSpec.describe "Favorites", type: :request do
 
       it 'remove shop from favorite with Hotwire' do
         expect {
-          delete favorite_path(favorite)
+          delete favorite_path(favorite), as: :turbo_stream
         }.to change(Favorite, :count).by(-1)
       end
     end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Favorites", type: :request do
-  let(:favorite) { create(:favorite) }
+  let(:user) { create(:user) }
+  let(:ramen_shop) { create(:ramen_shop) }
 
   describe 'POST /favorites #create' do
     context 'when not logged in' do
@@ -10,13 +11,51 @@ RSpec.describe "Favorites", type: :request do
         expect(response).to redirect_to login_path
       end
     end
+
+    context 'when logged in' do
+      before do
+        log_in_as user
+      end
+
+      it 'adds shop to favorite the standard way' do
+        expect {
+          post favorites_path, params: { ramen_shop_id: ramen_shop.id }
+        }.to change(Favorite, :count).by(1)
+      end
+
+      it 'adds shop to favorite with Hotwire' do
+        expect {
+          post favorites_path, params: { ramen_shop_id: ramen_shop.id }, as: :turbo_stream
+        }.to change(Favorite, :count).by(1)
+      end
+    end
   end
 
   describe 'DELETE /favorites/:id #destory' do
+    let!(:favorite) { create(:favorite, user: user, ramen_shop: ramen_shop) }
+
     context 'when not logged in' do
       it 'redirects to login_path' do
         delete favorite_path(favorite)
         expect(response).to redirect_to login_path
+      end
+    end
+
+    context 'when logged in' do
+      before do
+        log_in_as user
+      end
+
+      it 'remove shop from favorite the standard way' do
+        expect {
+          delete favorite_path(favorite)
+        }.to change(Favorite, :count).by(-1)
+      end
+
+      it 'remove shop from favorite with Hotwire' do
+        expect {
+          delete favorite_path(favorite)
+        }.to change(Favorite, :count).by(-1)
       end
     end
   end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :request do
+  let(:favorite) { create(:favorite) }
+
+  describe 'POST /favorites #create' do
+    context 'when not logged in' do
+      it 'redirects to login_path' do
+        post favorites_path
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+
+  describe 'DELETE /favorites/:id #destory' do
+    context 'when not logged in' do
+      it 'redirects to login_path' do
+        delete favorite_path(favorite)
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -175,4 +175,14 @@ RSpec.describe 'Users' do
       end
     end
   end
+
+  describe 'GET /user/:id/favorite_shops' do
+    let(:user) { create(:user) }
+    context 'when not logged in' do
+      it 'redirects to login_path' do
+        get favorites_by_user_path(user)
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe 'Users' do
 
   describe 'GET /user/:id/favorite_shops' do
     let(:user) { create(:user) }
+
     context 'when not logged in' do
       it 'redirects to login_path' do
         get favorites_by_user_path(user)

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Favorites", type: :system do
+RSpec.describe 'Favorites' do
   let(:user) { create(:user) }
   let(:ramen_shops) { create_list(:ramen_shop, 5) }
 
@@ -11,7 +11,7 @@ RSpec.describe "Favorites", type: :system do
     log_in_as(user)
   end
 
-  scenario "favorite_shops_page" do
+  scenario 'favorite_shops_page' do
     visit favorites_by_user_path(user)
     expect(page).to have_content 'お気に入り店 5'
     user.favorite_shops.each do |shop|

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :system do
+  let(:user) { create(:user) }
+  let(:ramen_shops) { create_list(:ramen_shop, 5) }
+
+  before do
+    ramen_shops.each do |ramen_shop|
+      create(:favorite, user: user, ramen_shop: ramen_shop)
+    end
+    log_in_as(user)
+  end
+
+  scenario "favorite_shops_page" do
+    visit favorites_by_user_path(user)
+    expect(page).to have_content 'お気に入り店 5'
+    user.favorite_shops.each do |shop|
+      expect(page).to have_link 'みてみる', href: ramen_shop_path(shop)
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
- お気に入り店登録・閲覧機能を追加
  - Favoriteモデル追加
    - user_idとramen_shop_idの複合インデックスを追加
    - ユーザーとラーメンショップの多対多を実現
  - RamenShopとUserモデルの改良
    - has_many関連付けによるメソッド生成
    - インスタンスメソッドを追加
      - favorite? : ユーザーがラーメン店をお気に入り登録しているか確認
      - add_favorite : ラーメン店をお気に入り登録
      - remove_favorite : ラーメン店をお気に入りから解除
      - favorite_by? : ユーザーからお気に入り登録されているか確認
  - Favoriteコントローラ追加
    - ログインしている時のみお気に入り登録・解除がができること
    - Turbo Streamでお気に入り登録・解除ボタンのみを置換する
  - ラーメン店ページにお気に入り操作ボタンを追加
  - ユーザーページの改善
    - statsパーシャルを追加しお気に入り登録数を表示
    - favorite_shopsアクションを追加しお気に入り店一覧表示
  - その他
    - ヘッダーのお気に入りリンクを更新
    - SeedファイルにFavoriteサンプルデータを追加
    - Specの追加
      - お気に入り表示ページのシステムスペック
      - Favoriteコントローラのリクエストスペック
      - Favoriteモデルのバリデーションスペック
      - Userモデルのお気に入り登録・解除のモデルスペック
      - RamenShopモデルのfavorite_by?メソッド検証

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス