### PR TITLE
Add result into record

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -46,7 +46,7 @@ class RecordsController < ApplicationController
     if @record.ended_at?
       redirect_to root_path, status: :see_other
     else
-      @record.calculate_wait_time!
+      @record.update!(calculated_record_params)
       forget_record
       redirect_to result_record_path(@record), notice: 'ちゃくどんレコードを登録しました', status: :see_other
     end
@@ -75,6 +75,10 @@ class RecordsController < ApplicationController
 
   def create_record_params
     params.require(:record).permit(:ramen_shop_id, :user_id, line_statuses_attributes: %i[line_number line_type comment])
+  end
+
+  def calculated_record_params
+    params.require(:record).permit(:ended_at, :wait_time)
   end
 
   def update_record_params

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -20,7 +20,7 @@ class RecordsController < ApplicationController
 
   def create
     @record = Record.new(create_record_params)
-    @record.assign_attributes(started_at: Time.zone.now)
+    # @record.assign_attributes(started_at: Time.zone.now)
 
     if @record.save
       redirect_to measure_record_path(@record), status: :see_other
@@ -74,7 +74,7 @@ class RecordsController < ApplicationController
   end
 
   def create_record_params
-    params.require(:record).permit(:ramen_shop_id, :user_id, line_statuses_attributes: %i[line_number line_type comment])
+    params.require(:record).permit(:ramen_shop_id, :user_id, :started_at, line_statuses_attributes: %i[line_number line_type comment])
   end
 
   def calculated_record_params

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,8 +1,8 @@
 class RecordsController < ApplicationController
   include RecordsHelper
 
-  before_action :logged_in_user, only: %i[new edit create measure calculate result update]
-  before_action :set_record, only: %i[show measure edit calculate result update]
+  before_action :logged_in_user, except: %i[show]
+  before_action :set_record, except: %i[new create]
   before_action :set_ramen_shop, except: %i[new create]
   before_action :disable_connect_button, only: %i[measure result]
 
@@ -20,7 +20,6 @@ class RecordsController < ApplicationController
 
   def create
     @record = Record.new(create_record_params)
-    # @record.assign_attributes(started_at: Time.zone.now)
 
     if @record.save
       redirect_to measure_record_path(@record), status: :see_other

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -73,7 +73,8 @@ class RecordsController < ApplicationController
   end
 
   def create_record_params
-    params.require(:record).permit(:ramen_shop_id, :user_id, :started_at, line_statuses_attributes: %i[line_number line_type comment])
+    params.require(:record).permit(:ramen_shop_id, :user_id, :started_at,
+                                   line_statuses_attributes: %i[line_number line_type comment])
   end
 
   def calculated_record_params

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -2,9 +2,16 @@ import { Controller } from "@hotwired/stimulus";
 import { Modal } from "bootstrap";
 
 export default class extends Controller {
+  static targets = ["startedAt"];
+
   connect() {
     this.modal = new Modal(this.element);
     this.modal.show();
+  }
+
+  fetchStartAt() {
+    const startedAt = new Date();
+    this.startedAtTarget.value = startedAt;
   }
 
   close(event) {

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -1,14 +1,12 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Connects to data-controller="timer"
 export default class extends Controller {
-  static targets = ["time", "started"];
+  static targets = ["time", "startedAt", "endedAt", "waitTime"];
 
   connect() {
     const timeElement = this.timeTarget;
-    const startedElement = this.startedTarget;
+    const startedAtValue = this.data.get("startedAt");
 
-    // Format time in HH:MM:SS.mmm
     const formatTime = (time) => {
       const hours = String(Math.floor(time / 3600)).padStart(2, "0");
       const minutes = String(Math.floor((time % 3600) / 60)).padStart(2, "0");
@@ -20,8 +18,7 @@ export default class extends Controller {
       return `${hours}:${minutes}:${seconds}.${milliseconds}`;
     };
 
-    // Start timer
-    const startTime = new Date(startedElement.value).getTime();
+    const startTime = new Date(startedAtValue).getTime();
     const updateTimer = () => {
       const currentTime = new Date().getTime();
       const elapsedTime = (currentTime - startTime) / 1000;
@@ -29,11 +26,17 @@ export default class extends Controller {
       timeElement.innerText = formatTime(elapsedTime);
     };
 
-    this.timer = setInterval(updateTimer, 10);
+    this.timer = setInterval(updateTimer, 1);
   }
 
   end() {
     clearInterval(this.timer);
+    const endedAt = new Date();
+    const startedAt = new Date(this.data.get("startedAt"));
+    const waitTime = (endedAt - startedAt) / 1000;
+
+    this.endedAtTarget.value = endedAt;
+    this.waitTimeTarget.value = waitTime;
   }
 
   disconnect() {

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -9,8 +9,11 @@ class Record < ApplicationRecord
   validates :comment, length: { maximum: 140 }
 
   def calculate_wait_time!
-    self.ended_at = Time.current
-    self.wait_time = ended_at - started_at
-    self
+    ended_at = Time.current
+    wait_time = ended_at - started_at
+    update!(
+      ended_at: ended_at,
+      wait_time: wait_time
+    )
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -7,13 +7,4 @@ class Record < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
 
   validates :comment, length: { maximum: 140 }
-
-  def calculate_wait_time!
-    ended_at = Time.current
-    wait_time = ended_at - started_at
-    update!(
-      ended_at: ended_at,
-      wait_time: wait_time
-    )
-  end
 end

--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -2,7 +2,6 @@
   <%= bootstrap_form_with model: @record, url: ramen_shop_records_path, data: { action: "turbo:submit-end->modal#close" } do |f| %>
     <%= f.hidden_field :ramen_shop_id %>
     <%= f.hidden_field :user_id %>
-    <%= f.hidden_field :started_at, id: 'started' %>
     <%= f.fields_for :line_statuses do |form| %>
       <%= render "line_statuses/form", f: form %>
     <% end %>

--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -2,9 +2,10 @@
   <%= bootstrap_form_with model: @record, url: ramen_shop_records_path, data: { action: "turbo:submit-end->modal#close" } do |f| %>
     <%= f.hidden_field :ramen_shop_id %>
     <%= f.hidden_field :user_id %>
+    <%= f.hidden_field :started_at, data: { modal_target: "startedAt" } %>
     <%= f.fields_for :line_statuses do |form| %>
       <%= render "line_statuses/form", f: form %>
     <% end %>
-    <%= f.submit class: "btn btn-sm btn-warning", data: { disable_with: '接続中...' } %>
+    <%= f.submit class: "btn btn-sm btn-warning", data: { action: "click->modal#fetchStartAt", disable_with: '接続中...' } %>
   <% end%>
 </div>

--- a/app/views/records/measure.html.erb
+++ b/app/views/records/measure.html.erb
@@ -2,7 +2,7 @@
 <p><%= @ramen_shop.address %></p>
 <div data-controller="timer">
   <div data-timer-target="time">00:00:00.000</div>
-  <%= bootstrap_form_with model: @record do |f| %>
+  <%= bootstrap_form_with model: @record, url: calculate_record_path do |f| %>
   <%= f.hidden_field :started_at, value: @record.started_at&.iso8601, data: { timer_target: "started" } %>
   <div class="d-grid">
     <%= f.submit 'ちゃくどん', data: { action: "click->timer#end" } , class: "btn btn-warning" %>

--- a/app/views/records/measure.html.erb
+++ b/app/views/records/measure.html.erb
@@ -1,14 +1,15 @@
 <p><%= @ramen_shop.name %></p>
 <p><%= @ramen_shop.address %></p>
-<div data-controller="timer">
+<div data-controller="timer" data-timer-started-at="<%= @record.started_at&.iso8601 %>">
   <div data-timer-target="time">00:00:00.000</div>
   <%= bootstrap_form_with model: @record, url: calculate_record_path do |f| %>
-  <%= f.hidden_field :started_at, value: @record.started_at&.iso8601, data: { timer_target: "started" } %>
-  <div class="d-grid">
-    <%= f.submit 'ちゃくどん', data: { action: "click->timer#end" } , class: "btn btn-warning" %>
-  </div>
+    <%= f.hidden_field :ended_at, data: { timer_target: "endedAt" } %>
+    <%= f.hidden_field :wait_time, data: { timer_target: "waitTime" } %>
+    <div class="d-grid">
+      <%= f.submit 'ちゃくどん', data: { action: "click->timer#end" } , class: "btn btn-warning" %>
+    </div>
+  <% end %>
 </div>
-<% end %>
 <div class="my-3 p-3 bg-body rounded shadow-sm">
   <div class="d-flex justify-content-between border-bottom pb-2 mb-0">
     <h6><%= tag.span("行列の様子") %></h6>

--- a/app/views/records/result.html.erb
+++ b/app/views/records/result.html.erb
@@ -1,0 +1,10 @@
+<h1>ちゃくどん！</h1>
+<p class="fs-2 mb-1"><%= format_wait_time @record.wait_time %></p>
+<p>接続: <%= format_datetime @record.started_at %></p>
+<p>着丼: <%= format_datetime @record.ended_at %></p>
+<%= bootstrap_form_with model: @record do |f| %>
+  <%= f.text_area :comment, label: { text: "着丼してひとこと" } %>
+  <div class="d-grid">
+    <%= f.submit '投稿する', class: "btn btn-warning" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   resources :ramen_shops, only: [:index, :show] do
     resources :records, only: [:show, :new, :create, :edit, :update], shallow: true do
       get 'measure', on: :member
+      patch 'calculate', on: :member
+      get 'result', on: :member
       resources :line_statuses
     end
   end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -94,7 +94,13 @@ RSpec.describe 'Records' do
 
 
   describe 'GET /records/:id/calculate #calculate' do
-    let(:do_request) { patch calculate_record_path(record) }
+    let(:do_request) { patch calculate_record_path(record), params: calculated_record_params }
+    let(:calculated_record_params) do
+      started_at = record.started_at
+      ended_at = Time.now
+      wait_time = ended_at - started_at
+      { record: { ended_at: ended_at, wait_time: wait_time } }
+    end
 
     it_behaves_like 'when not logged in'
 

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Records' do
       { record: {
         ramen_shop_id: ramen_shop.id,
         user_id: user.id,
-        started_at: nil,
+        started_at: Time.now,
         line_statuses_attributes: [
           line_number: 1,
           line_type: 'inside_the_store',

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Records' do
       { record: {
         ramen_shop_id: ramen_shop.id,
         user_id: user.id,
-        started_at: Time.now,
+        started_at: Time.zone.now,
         line_statuses_attributes: [
           line_number: 1,
           line_type: 'inside_the_store',
@@ -92,12 +92,11 @@ RSpec.describe 'Records' do
     end
   end
 
-
   describe 'GET /records/:id/calculate #calculate' do
     let(:do_request) { patch calculate_record_path(record), params: calculated_record_params }
     let(:calculated_record_params) do
       started_at = record.started_at
-      ended_at = Time.now
+      ended_at = Time.zone.now
       wait_time = ended_at - started_at
       { record: { ended_at: ended_at, wait_time: wait_time } }
     end
@@ -116,7 +115,7 @@ RSpec.describe 'Records' do
       end
 
       it 'redirects to root_path if ended' do
-        record.update(ended_at: Time.now)
+        record.update(ended_at: Time.zone.now)
         do_request
         expect(response).to redirect_to root_path
       end

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -52,11 +52,19 @@ RSpec.describe 'Records', js: true do
     expect(page).to have_content '00:00:05', wait: 2
     click_button 'ちゃくどん'
 
-    # 着丼後のRecordページ
+    # 着丼後の投稿ページ
     expect(page).to have_content 'ちゃくどんレコードを登録しました'
     expect(page).to have_content '00:00:05'
+    fill_in '着丼してひとこと', with: '着丼しました'
+    click_button '投稿する'
 
-    # ブラウザバックするとmeasureページでなくroot_pathへリダイレクト
+    # Recordページ
+    expect(page).to have_content '投稿しました'
+    expect(page).to have_content '00:00:05'
+    expect(page).to have_content '着丼しました'
+
+    # measureまでブラウザバックするとroot_pathへリダイレクト
+    go_back
     go_back
     expect(page).to have_current_path(root_path)
     expect(page).to have_link '現在地からセツゾク'


### PR DESCRIPTION
## やったこと
- 着丼後のひとことコメント投稿機能を追加
  - recordsコントローラにresultアクションを追加
    - ひとことコメント投稿フォームを表示
  - recordsコントローラにcalculateアクションを追加
    - フロントで算出済みのパラメータをもとにレコードを更新
  - recordsコントローラ内で使用するparamsはアクションごとに明確に指定するよう修正
- fixed #46 
  - modalコントローラへfetchStartAtを追加し接続時の行列情報投稿ボタンを押したタイミングをstarted_atとする
  - timerコントローラのendを改善し、計測画面のちゃくどんボタンを押したタイミングをend_atとし、wait_timeも同時に算出して送信
- 改良した内容を検証するスペックを追加

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス