### PR TITLE
リタイア機能を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -218,3 +218,11 @@ aside {
     margin-bottom: 15px;
   }
 }
+
+.retire a {
+  text-decoration: none;
+  color: #4e4a4a;
+  &:hover{
+    text-decoration: underline solid #4e4a4a;
+  }
+}

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -3,7 +3,7 @@ class RecordsController < ApplicationController
 
   before_action :logged_in_user, except: %i[show]
   before_action :set_record, except: %i[new create]
-  before_action :set_ramen_shop, except: %i[new create]
+  before_action :set_ramen_shop, except: %i[new create retire]
   before_action :disable_connect_button, only: %i[measure result]
 
   def show
@@ -33,7 +33,7 @@ class RecordsController < ApplicationController
     if remember_record?
       set_record_from_cookies
       flash.notice = '再セツゾクしました'
-    elsif @record.ended_at?
+    elsif @record.ended_at? || @record.is_retired?
       redirect_to root_path, status: :see_other
     else
       remember_record
@@ -60,6 +60,12 @@ class RecordsController < ApplicationController
     else
       render :result, status: :unprocessable_entity
     end
+  end
+
+  def retire
+    @record.update!(is_retired: true)
+    forget_record
+    redirect_to root_path, notice: 'リタイアしました', status: :see_other
   end
 
   private

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -63,7 +63,7 @@ class RecordsController < ApplicationController
   end
 
   def retire
-    @record.update!(is_retired: true)
+    @record.calculate_wait_time_for_retire!
     forget_record
     redirect_to root_path, notice: 'リタイアしました', status: :see_other
   end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -14,4 +14,10 @@ class Record < ApplicationRecord
                                     message: 'のフォーマットが不正です' },
                     size: { less_than_or_equal_to: 5.megabytes,
                             message: 'は5MB以下である必要があります' }
+
+  def calculate_wait_time_for_retire!
+    update!(is_retired: true,
+            ended_at: Time.current,
+            wait_time: Time.current - started_at)
+  end
 end

--- a/app/views/records/_record.html.erb
+++ b/app/views/records/_record.html.erb
@@ -7,7 +7,14 @@
     </div>
     <div class="d-flex justify-content-between align-items-end">
       <div>
-        <p class="fs-2 mb-1"><%= format_wait_time record.wait_time %></p>
+        <div class="record-value d-flex align-items-center">
+          <span class="fs-2 me-2"><%= format_wait_time record.wait_time %></span>
+          <% if record.is_retired? %>
+            <span class="badge rounded-pill bg-secondary">リタイア</span>
+          <% else %>
+            <span class="badge rounded-pill bg-primary">ちゃくどん</span>
+          <% end %>
+        </div>
         <% if record.comment %>
           <p class="mb-1">ひとこと: <%= record.comment %></p>
         <% end %>

--- a/app/views/records/measure.html.erb
+++ b/app/views/records/measure.html.erb
@@ -5,10 +5,13 @@
   <%= bootstrap_form_with model: @record, url: calculate_record_path do |f| %>
     <%= f.hidden_field :ended_at, data: { timer_target: "endedAt" } %>
     <%= f.hidden_field :wait_time, data: { timer_target: "waitTime" } %>
-    <div class="d-grid">
+    <div class="d-grid mb-3">
       <%= f.submit 'ちゃくどん', data: { action: "click->timer#end" } , class: "btn btn-warning" %>
     </div>
   <% end %>
+</div>
+<div class="retire d-flex justify-content-center">
+  <%= link_to 'リタイアする', retire_record_path(@record), data: { turbo_method: :post, turbo_confirm: "本当にリタイアしますか？" } %>
 </div>
 <div class="my-3 p-3 bg-body rounded shadow-sm">
   <div class="d-flex justify-content-between border-bottom pb-2 mb-0">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,12 @@ Rails.application.routes.draw do
 
   resources :ramen_shops, only: [:index, :show] do
     resources :records, only: [:show, :new, :create, :edit, :update], shallow: true do
-      get 'measure', on: :member
-      patch 'calculate', on: :member
-      get 'result', on: :member
+      member do
+        get 'measure'
+        patch 'calculate'
+        get 'result'
+        post 'retire'
+      end
       resources :line_statuses, except: [:index, :destroy]
     end
   end

--- a/db/migrate/20230731102013_add_retired_to_records.rb
+++ b/db/migrate/20230731102013_add_retired_to_records.rb
@@ -1,0 +1,5 @@
+class AddRetiredToRecords < ActiveRecord::Migration[7.0]
+  def change
+    add_column :records, :is_retired, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_29_060116) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_31_102013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_29_060116) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.boolean "is_retired", default: false
     t.index ["ramen_shop_id"], name: "index_records_on_ramen_shop_id"
     t.index ["user_id", "created_at"], name: "index_records_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_records_on_user_id"

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     ended_at { 1.minute.ago }
     wait_time { 600 }
     comment { 'いただきます！' }
+    is_retired { false }
     ramen_shop
     user
 

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe 'Records' do
           expect(response).to redirect_to root_path
         end
       end
+
+      context 'when the record.is_retired? is true' do
+        it 'redirects to root_path' do
+          log_in_as(user)
+          record.update(is_retired: true)
+          do_request
+          expect(response).to redirect_to root_path
+        end
+      end
     end
   end
 
@@ -165,6 +174,28 @@ RSpec.describe 'Records' do
         invalid_record_params = { record: { comment: 'a' * 141 } }
         patch record_path(record), params: invalid_record_params
         expect(response.body).to include 'は140文字以内で入力してください'
+      end
+    end
+  end
+
+  describe 'POST /records/:id/retire #retire' do
+    let(:do_request) { post retire_record_path(record) }
+
+    it_behaves_like 'when not logged in'
+
+    context 'when logged in' do
+      before do
+        log_in_as(user)
+      end
+
+      it 'updates is_retired true' do
+        do_request
+        expect(record.reload.is_retired).to be_truthy
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
       end
     end
   end

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Records', js: true do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, is_test_mode: true) }
   let!(:ramen_shop) { create(:ramen_shop) }
 
   before do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -105,15 +105,25 @@ RSpec.describe 'Users' do
       expect(page).to have_link 'ユーザー情報を編集する', href: edit_user_path(user)
     end
 
-    it 'shows their records' do
+    it 'shows their profile and records' do
       create_list(:many_records, 15, user: user)
+      create(:record, user: user, is_retired: true)
+
       visit user_path(user)
       expect(find('h1')).to have_content user.name
       expect(find('h1>img.avatar')).to be_truthy
       expect(find('h6>span')).to have_content user.records.count
       expect(find('ul.pagination')).to be_truthy
+
       user.records.page(1).each do |record|
         expect(page).to have_content format_datetime(record.created_at)
+        expect(page).to have_content format_wait_time(record.wait_time)
+
+        if record.is_retired?
+          expect(page).to have_content 'リタイア'
+        else
+          expect(page).to have_content 'ちゃくどん'
+        end
       end
     end
   end


### PR DESCRIPTION
## やったこと
- リタイア機能を追加
  - Recordモデルの改良
    - is_retireカラムを追加
    - リタイアまでの待ち時間を計測するcalculate_wait_time_for_retire!メソッドを定義
  - recordsコントローラの改良
    - retireアクションを追加
    - リタイア後にmeasureアクセスしようとした場合root_pathにリダイレクトさせるよう修正
  - measureページへリタイアボタンを追加
  - 検証スペック追加
    - retireアクションへの認証検証
    - レコード一覧ページでのタグ表記を検証

## できるようになること
- 待ち時間計測中に何らかの理由でラーメンを諦める場合に、リタイアできるようになる
- レコード一覧でリタイアしたものかちゃくどんしたものかタグ表記で判別できるようになる


## 動作確認
レコード一覧でのタグ表記
![image](https://github.com/moriw0/tyakudon/assets/87155363/1e527660-3ec7-4d4e-a4d2-b1bba48d68f5)

### RuboCop
指摘なし
### RSpec
全てパス