### PR TITLE
待ち状態タイプに着席状態を追加し、タイプ選択・表示UIを改善

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -226,3 +226,73 @@ aside {
     text-decoration: underline solid #4e4a4a;
   }
 }
+
+.type-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  font-size: 85%;
+  font-weight: 450;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 5px;
+  color: var(--bs-gray-800);
+  border: 0.37px solid #ccc3c3;
+}
+
+.type-badge::before {
+  content: "";
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  margin-right: 5px;
+  border-radius: 50%;
+  margin-bottom: 1px;
+  opacity: 0.6;
+}
+
+.badge-red {
+  background-color: rgba(232, 142, 142, 0.22);
+}
+
+.badge-red::before {
+  background-color: #DF5000;
+}
+
+.badge-yellow {
+  background-color: rgba(224, 253, 177, 0.31);
+}
+
+.badge-yellow::before {
+  background-color: #C8942F;
+}
+
+.badge-green {
+  background-color: rgba(13, 171, 86, 0.22);
+}
+
+.badge-green::before {
+  background-color: #1F950C;
+}
+
+.hidden-radio {
+  display: none;
+}
+
+div[data-controller="line-status"] {
+  .form-check {
+    padding: 0;
+    margin-left: 1.0rem;
+  }
+}
+
+.hidden-radio + label {
+  cursor: pointer;
+}
+
+.hidden-radio:checked + label {
+  border-color: #80bdff;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}

--- a/app/helpers/line_statuses_helper.rb
+++ b/app/helpers/line_statuses_helper.rb
@@ -1,2 +1,12 @@
 module LineStatusesHelper
+  def line_type_badge(line_status)
+    case line_status.line_type
+    when 'seated'
+      content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-green')
+    when 'inside_the_store'
+      content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-yellow')
+    when 'outside_the_store'
+      content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-red')
+    end
+  end
 end

--- a/app/javascript/controllers/line_status_controller.js
+++ b/app/javascript/controllers/line_status_controller.js
@@ -2,17 +2,18 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="line-status"
 export default class extends Controller {
-  static targets = ["lineNumberInput"];
+  static targets = ["lineNumberField", "lineNumberInput"];
 
   updateNumberInput(event) {
     const lineTypeRadio = event.target;
     const lineNumberInput = this.lineNumberInputTarget;
+    const lineNumberField = this.lineNumberFieldTarget;
 
     if (lineTypeRadio.value === "seated") {
-      lineNumberInput.disabled = true;
-      lineNumberInput.value = "";
+      lineNumberField.style.display = "none";
+      lineNumberInput.value = 0;
     } else {
-      lineNumberInput.disabled = false;
+      lineNumberField.style.display = "block";
       lineNumberInput.value = "";
     }
   }

--- a/app/javascript/controllers/line_status_controller.js
+++ b/app/javascript/controllers/line_status_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="line-status"
+export default class extends Controller {
+  static targets = ["lineNumberInput"];
+
+  updateNumberInput(event) {
+    const lineTypeRadio = event.target;
+    const lineNumberInput = this.lineNumberInputTarget;
+
+    if (lineTypeRadio.value === "seated") {
+      lineNumberInput.disabled = true;
+      lineNumberInput.value = "";
+    } else {
+      lineNumberInput.disabled = false;
+      lineNumberInput.value = "";
+    }
+  }
+}

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -4,9 +4,9 @@ class LineStatus < ApplicationRecord
     attachable.variant :display, resize_to_limit: [250, 250]
   end
 
-  enum line_type: { inside_the_store: 1, outside_the_store: 2, other: 3 }
+  enum line_type: { inside_the_store: 1, outside_the_store: 2, seated: 3 }
 
-  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, unless: :seated?
   validates :comment, length: { maximum: 140, too_long: '最大%<count>s文字まで使えます' }
   validates :image, content_type: { in: %i[png jpg jpeg],
                                     message: 'のフォーマットが不正です' },

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -6,7 +6,7 @@ class LineStatus < ApplicationRecord
 
   enum line_type: { inside_the_store: 1, outside_the_store: 2, seated: 3 }
 
-  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, unless: :seated?
+  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :comment, length: { maximum: 140, too_long: '最大%<count>s文字まで使えます' }
   validates :image, content_type: { in: %i[png jpg jpeg],
                                     message: 'のフォーマットが不正です' },

--- a/app/views/line_statuses/_form.html.erb
+++ b/app/views/line_statuses/_form.html.erb
@@ -1,12 +1,14 @@
 <div data-controller="line-status">
   <%= f.form_group :line_type, label: { text: "接続先" }, data: { action: "change->line-status#updateNumberInput" } do %>
     <div class="d-flex">
-      <%= f.radio_button :line_type, :seated,            label: "着席", class: 'hidden-radio', label_class: "type-badge badge-green", checked: true %>
+      <%= f.radio_button :line_type, :outside_the_store, label: "店外", class: 'hidden-radio', label_class: "type-badge badge-red", checked: true %>
       <%= f.radio_button :line_type, :inside_the_store,  label: '店内', class: 'hidden-radio', label_class: "type-badge badge-yellow" %>
-      <%= f.radio_button :line_type, :outside_the_store, label: "店外", class: 'hidden-radio', label_class: "type-badge badge-red" %>
+      <%= f.radio_button :line_type, :seated,            label: "着席", class: 'hidden-radio', label_class: "type-badge badge-green" %>
     </div>
   <% end %>
-  <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" }, disabled: true %>
+  <div class="line-number-box" data-line-status-target="lineNumberField">
+    <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" } %>
+  </div>
 </div>
 <%= f.text_area :comment, label: { text: "ひとこと" } %>
 <div class="image" data-controller="image-uploader">

--- a/app/views/line_statuses/_form.html.erb
+++ b/app/views/line_statuses/_form.html.erb
@@ -1,9 +1,13 @@
-<%= f.text_field :line_number %>
-<%= f.form_group :line_type, label: { text: "接続先" } do %>
-  <%= f.radio_button :line_type, :inside_the_store, label: "店内", checked: true %>
-  <%= f.radio_button :line_type, :outside_the_store, label: "店外" %>
-  <%= f.radio_button :line_type, :other, label: "その他" %>
-<% end %>
+<div data-controller="line-status">
+  <%= f.form_group :line_type, label: { text: "接続先" }, data: { action: "change->line-status#updateNumberInput" } do %>
+    <div class="d-flex">
+      <%= f.radio_button :line_type, :seated,            label: "着席", class: 'hidden-radio', label_class: "type-badge badge-green", checked: true %>
+      <%= f.radio_button :line_type, :inside_the_store,  label: '店内', class: 'hidden-radio', label_class: "type-badge badge-yellow" %>
+      <%= f.radio_button :line_type, :outside_the_store, label: "店外", class: 'hidden-radio', label_class: "type-badge badge-red" %>
+    </div>
+  <% end %>
+  <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" }, disabled: true %>
+</div>
 <%= f.text_area :comment, label: { text: "ひとこと" } %>
 <div class="image" data-controller="image-uploader">
   <%= f.file_field :image, accept: "image/jpeg,image/jpg,image/png", data: { action: "change->image-uploader#displayAfterCheck", image_uploader_target: "image" } %>

--- a/app/views/line_statuses/_line_status.html.erb
+++ b/app/views/line_statuses/_line_status.html.erb
@@ -9,7 +9,7 @@
       <div class="d-flex justify-content-between align-items-end">
         <div>
           <p class="mb-1"><%= line_type_badge(line_status) %></p>
-          <% if line_status.line_number.present? %>
+          <% unless line_status.seated? %>
             <p class="mb-1">待ち行列: <%= line_status.line_number %></p>
           <% end %>
           <% if line_status.comment.present? %>

--- a/app/views/line_statuses/_line_status.html.erb
+++ b/app/views/line_statuses/_line_status.html.erb
@@ -8,8 +8,10 @@
       </div>
       <div class="d-flex justify-content-between align-items-end">
         <div>
-          <p class="mb-1">待ち行列: <%= line_status.line_number %></p>
-          <p class="mb-1"><%= line_status.line_type_i18n %></p>
+          <p class="mb-1"><%= line_type_badge(line_status) %></p>
+          <% if line_status.line_number.present? %>
+            <p class="mb-1">待ち行列: <%= line_status.line_number %></p>
+          <% end %>
           <% if line_status.comment.present? %>
             <p class="mb-1">ひとこと: <%= line_status.comment %></p>
           <% end %>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -27,9 +27,10 @@ ja:
         line_number: 待ち行列数
         line_type: タイプ
         comment: コメント
+        image: 写真
   enums:
     line_status:
       line_type:
         inside_the_store: 店内
         outside_the_store: 店外
-        other: その他
+        seated: 着席

--- a/spec/models/line_status_spec.rb
+++ b/spec/models/line_status_spec.rb
@@ -19,31 +19,10 @@ RSpec.describe LineStatus do
     expect { line_status.line_type = 'invalid' }.to raise_error(ArgumentError, "'invalid' is not a valid line_type")
   end
 
-  context 'with blank line_number' do
-    let(:line_status) { build(:line_status, line_number: '') }
-
-    context 'when line_type is inside the store' do
-      it 'is invalid' do
-        line_status.line_type = 'inside_the_store'
-        line_status.valid?
-        expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
-      end
-    end
-
-    context 'when line_type is outside the store' do
-      it 'is invalid' do
-        line_status.line_type = 'outside_the_store'
-        line_status.valid?
-        expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
-      end
-    end
-
-    context 'when line_type is seated' do
-      it 'is valid' do
-        line_status.line_type = 'seated'
-        expect(line_status).to be_valid
-      end
-    end
+  it 'is invalid with blank line_number' do
+    line_status.line_number = ''
+    line_status.valid?
+    expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
   end
 
   it 'is invalid with string line_number' do

--- a/spec/models/line_status_spec.rb
+++ b/spec/models/line_status_spec.rb
@@ -19,10 +19,31 @@ RSpec.describe LineStatus do
     expect { line_status.line_type = 'invalid' }.to raise_error(ArgumentError, "'invalid' is not a valid line_type")
   end
 
-  it 'is invalid with blank line_number' do
-    line_status.line_number = ''
-    line_status.valid?
-    expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
+  context 'with blank line_number' do
+    let(:line_status) { build(:line_status, line_number: '') }
+
+    context 'when line_type is inside the store' do
+      it 'is invalid' do
+        line_status.line_type = 'inside_the_store'
+        line_status.valid?
+        expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
+      end
+    end
+
+    context 'when line_type is outside the store' do
+      it 'is invalid' do
+        line_status.line_type = 'outside_the_store'
+        line_status.valid?
+        expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
+      end
+    end
+
+    context 'when line_type is seated' do
+      it 'is valid' do
+        line_status.line_type = 'seated'
+        expect(line_status).to be_valid
+      end
+    end
   end
 
   it 'is invalid with string line_number' do

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Records', js: true do
 
     # 接続するラーメン店を選択して最初の待ち行列情報を入力
     click_link ramen_shop.name, href: new_ramen_shop_record_path(ramen_shop)
+    find('label[for="record_line_statuses_attributes_0_line_type_outside_the_store"]').click
     fill_in '待ち行列数', with: 5
-    choose '店内'
     fill_in 'ひとこと', with: '並ぶぞ'
     click_button '登録する'
 
@@ -35,21 +35,29 @@ RSpec.describe 'Records', js: true do
     record = Record.last
     click_link '接続中レコード', href: measure_record_path(record)
     expect(page).to have_content '再セツゾクしました'
-    expect(page).to have_content '00:00:03', wait: 3
+    expect(page).to have_content '00:00:02', wait: 2
 
     # 待ち行列状況を追加登録
     click_link '追加登録'
+    find('label[for="line_status_line_type_outside_the_store"]').click
     fill_in '待ち行列数', with: 1
-    choose '店内'
+    ## 着席を選択すると数値がリセットされdisabledとなる
+    find('label[for="line_status_line_type_seated"]').click
+    expect(find_by_id('line_status_line_number').value).to eq ''
+    expect(page).to have_css('input#line_status_line_number[disabled]')
+    ## 着席以外を選択すると再び数値入力ができるようになる
+    find('label[for="line_status_line_type_inside_the_store"]').click
+    fill_in '待ち行列数', with: 1
     fill_in 'ひとこと', with: 'もう少し'
     click_button '登録する'
-    sleep(1) # 暫定対策: responseを待ってからmodalを強制的に閉じる
+    ## 暫定対策: responseを待ってからmodalを強制的に閉じる
+    sleep(1)
     find('button[data-bs-dismiss="modal"]').click
 
     # measureページに追加登録情報が反映されている
     expect(page).to have_content '行列の様子を登録しました'
     expect(page).to have_content 'もう少し'
-    expect(page).to have_content '00:00:05', wait: 2
+    expect(page).to have_content '00:00:05', wait: 3
     click_button 'ちゃくどん'
 
     # 着丼後の投稿ページ

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -41,10 +41,9 @@ RSpec.describe 'Records', js: true do
     click_link '追加登録'
     find('label[for="line_status_line_type_outside_the_store"]').click
     fill_in '待ち行列数', with: 1
-    ## 着席を選択すると数値がリセットされdisabledとなる
+    ## 着席を選択すると行列数が0でhiddenされる
     find('label[for="line_status_line_type_seated"]').click
-    expect(find_by_id('line_status_line_number').value).to eq ''
-    expect(page).to have_css('input#line_status_line_number[disabled]')
+    expect(find_by_id('line_status_line_number', visible: :hidden).value).to eq '0'
     ## 着席以外を選択すると再び数値入力ができるようになる
     find('label[for="line_status_line_type_inside_the_store"]').click
     fill_in '待ち行列数', with: 1


### PR DESCRIPTION
## やったこと
- 待ち状態タイプに着席状態を追加し、タイプ選択・表示UIを改善
  - タイプに応じて表示デザインを変更するline_type_badgeヘルパーを作成

  - LineStatusモデルの改善
    - line_typeのotherを着席状態を表すseatedに変更
  - LineStatus投稿フォームの改善
    - 待ち状態タイプのラジオボタンを表示バッジに対応させたUIに変更
    - 待ち状態投稿フォームで状態タイプによって待ち行列数を変化させるstimulusコントローラを作成
      - 着席を選択すると待ち行列数0にして入力フィールドを非表示にする
      - それ以外のタイプを選択すると待ち行列数インプットボックスを入力可能とする。
  - レコード作成systemスペックを修正

## できるようになること
テキストだけではタイプ選択に迷いが生じるが、色分けしたバッチにより視覚的に選択判断ができるようになる

## 動作確認
- フォーム画面
<img width="339" alt="image" src="https://github.com/moriw0/tyakudon/assets/87155363/6771d2ba-8e38-4295-a82b-79f921adf30b">

- line_status表示画面
<img width="364" alt="image" src="https://github.com/moriw0/tyakudon/assets/87155363/4c21e8b4-e3a6-436c-b0f3-66424614cf40">

### RuboCop
指摘なし
### RSpec
全てパス