### PR TITLE
DelayedJobを導入して接続後1日経過するレコードを無効にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'faker'
 gem 'seed-fu'
 gem 'active_storage_validations'
 gem "aws-sdk-s3"
+gem 'delayed_job_active_record'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,11 @@ GEM
     debug (1.7.2)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    delayed_job (4.1.11)
+      activesupport (>= 3.0, < 8.0)
+    delayed_job_active_record (4.1.7)
+      activerecord (>= 3.0, < 8.0)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -367,6 +372,7 @@ DEPENDENCIES
   capybara
   dartsass-rails
   debug
+  delayed_job_active_record
   dotenv-rails
   enum_help
   factory_bot_rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server -p 3000
 css: bin/rails dartsass:watch
+worker: bin/rails jobs:work

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -105,9 +105,9 @@ class RecordsController < ApplicationController
   end
 
   def check_auto_retired
-    if @record.auto_retired?
-      forget_record
-      redirect_to root_path, notice: '記録は無効になっています', status: :see_other
-    end
+    return unless @record.auto_retired?
+
+    forget_record
+    redirect_to root_path, notice: '記録は無効になっています', status: :see_other
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -4,6 +4,7 @@ class RecordsController < ApplicationController
   before_action :logged_in_user, except: %i[show]
   before_action :set_record, except: %i[new create]
   before_action :set_ramen_shop, except: %i[new create retire]
+  before_action :check_auto_retired, only: %i[measure calculate retire]
   before_action :disable_connect_button, only: %i[measure result]
 
   def show
@@ -30,11 +31,11 @@ class RecordsController < ApplicationController
   end
 
   def measure
-    if remember_record?
+    if @record.ended_at?
+      redirect_to root_path, status: :see_other
+    elsif remember_record?
       set_record_from_cookies
       flash.notice = '再セツゾクしました'
-    elsif @record.ended_at? || @record.is_retired?
-      redirect_to root_path, status: :see_other
     else
       remember_record
       flash.notice = 'セツゾクしました'
@@ -101,5 +102,12 @@ class RecordsController < ApplicationController
 
   def forget_record
     cookies.delete(:record_id)
+  end
+
+  def check_auto_retired
+    if @record.auto_retired?
+      forget_record
+      redirect_to root_path, notice: '記録は無効になっています', status: :see_other
+    end
   end
 end

--- a/app/jobs/auto_retire_record_job.rb
+++ b/app/jobs/auto_retire_record_job.rb
@@ -1,0 +1,8 @@
+class AutoRetireRecordJob < ApplicationJob
+  queue_as :default
+
+  def perform(record)
+    record.auto_retire!
+    UserMailer.notify_retirement(record.user, record).deliver_now
+  end
+end

--- a/app/jobs/auto_retire_record_job.rb
+++ b/app/jobs/auto_retire_record_job.rb
@@ -2,6 +2,8 @@ class AutoRetireRecordJob < ApplicationJob
   queue_as :default
 
   def perform(record)
+    return if record.ended_at?
+
     record.auto_retire!
     UserMailer.notify_retirement(record.user, record).deliver_now
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,6 @@
 class UserMailer < ApplicationMailer
+  helper ApplicationHelper
+
   def account_activation(user)
     @user = user
     mail to: user.email, subject: 'アカウントの有効化に関して'
@@ -7,5 +9,11 @@ class UserMailer < ApplicationMailer
   def password_reset(user)
     @user = user
     mail to: user.email, subject: 'パスワードリセットについて'
+  end
+
+  def notify_retirement(user, record)
+    @user = user
+    @record = record
+    mail(to: @user.email, subject: 'ちゃくどん記録が無効になりました')
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -14,10 +14,21 @@ class Record < ApplicationRecord
                                     message: 'のフォーマットが不正です' },
                     size: { less_than_or_equal_to: 5.megabytes,
                             message: 'は5MB以下である必要があります' }
+  after_create :schedule_auto_retire
 
   def calculate_wait_time_for_retire!
     update!(is_retired: true,
             ended_at: Time.current,
             wait_time: Time.current - started_at)
+  end
+
+  def auto_retire!
+    update!(auto_retired: true)
+  end
+
+  private
+
+  def schedule_auto_retire
+    AutoRetireRecordJob.set(wait: 1.day).perform_later(self)
   end
 end

--- a/app/views/user_mailer/notify_retirement.html.erb
+++ b/app/views/user_mailer/notify_retirement.html.erb
@@ -1,0 +1,5 @@
+<p>こんにちは <%= @user.name %> さん</p>
+<p>下記の記録は24時間以上ちゃくどんされなかったため、無効になったことをお知らせいたします。</p>
+<p>店舗名　： <%= @record.ramen_shop.name %></p>
+<p>接続時刻： <%= format_datetime(@record.started_at) %></p>
+<p>またのご利用をお待ちしております！</p>

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,6 @@ module Tyakudon
     end
     config.active_storage.variant_processor = :mini_magick
 
-    config.active_job.queue_adapter = :delayed_job
+    # config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,7 @@ module Tyakudon
         routing_specs: false
     end
     config.active_storage.variant_processor = :mini_magick
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/db/migrate/20230804093444_add_auto_retired_to_records.rb
+++ b/db/migrate/20230804093444_add_auto_retired_to_records.rb
@@ -1,0 +1,5 @@
+class AddAutoRetiredToRecords < ActiveRecord::Migration[7.0]
+  def change
+    add_column :records, :auto_retired, :boolean, default: false
+  end
+end

--- a/db/migrate/20230804123310_create_delayed_jobs.rb
+++ b/db/migrate/20230804123310_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_31_102013) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_04_123310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_102013) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "favorites", force: :cascade do |t|
@@ -81,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_102013) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.boolean "is_retired", default: false
+    t.boolean "auto_retired", default: false
     t.index ["ramen_shop_id"], name: "index_records_on_ramen_shop_id"
     t.index ["user_id", "created_at"], name: "index_records_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_records_on_user_id"

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     wait_time { 600 }
     comment { 'いただきます！' }
     is_retired { false }
+    auto_retired { false }
     ramen_shop
     user
 

--- a/spec/jobs/auto_retire_record_job_spec.rb
+++ b/spec/jobs/auto_retire_record_job_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe AutoRetireRecordJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include ActiveJob::TestHelper
+
+  before do
+    clear_enqueued_jobs
+    clear_performed_jobs
+    ActionMailer::Base.deliveries.clear
+  end
+
+  it 'queues the job after create record' do
+    expect {
+      create(:record)
+    }.to change(enqueued_jobs, :size).by(1)
+  end
+
+  context 'executes perform' do
+    let!(:record) { create(:record) }
+
+    it 'makes record be auto_retired' do
+      perform_enqueued_jobs do
+        described_class.perform_later(record)
+      end
+
+      expect(record.reload.auto_retired).to be_truthy
+    end
+
+    it 'sends an email' do
+      perform_enqueued_jobs do
+        described_class.perform_later(record)
+      end
+
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
 end

--- a/spec/jobs/auto_retire_record_job_spec.rb
+++ b/spec/jobs/auto_retire_record_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AutoRetireRecordJob do
   end
 
   describe 'executes perform' do
-    let!(:record) { create(:record) }
+    let!(:record) { create(:record, ended_at: nil) }
 
     it 'makes record be auto_retired' do
       perform_enqueued_jobs do

--- a/spec/jobs/auto_retire_record_job_spec.rb
+++ b/spec/jobs/auto_retire_record_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe AutoRetireRecordJob, type: :job do
+RSpec.describe AutoRetireRecordJob do
   include ActiveJob::TestHelper
 
   before do
@@ -15,7 +15,7 @@ RSpec.describe AutoRetireRecordJob, type: :job do
     }.to change(enqueued_jobs, :size).by(1)
   end
 
-  context 'executes perform' do
+  describe 'executes perform' do
     let!(:record) { create(:record) }
 
     it 'makes record be auto_retired' do

--- a/spec/jobs/auto_retire_record_job_spec.rb
+++ b/spec/jobs/auto_retire_record_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AutoRetireRecordJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -13,4 +13,11 @@ class UserMailerPreview < ActionMailer::Preview
     user.reset_token = User.new_token
     UserMailer.password_reset(user)
   end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/notify_retirement
+  def notify_retirement
+    user = User.first
+    record = user.records.first
+    UserMailer.notify_retirement(user, record)
+  end
 end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -82,18 +82,20 @@ RSpec.describe 'Records' do
     it_behaves_like 'when not logged in'
 
     context 'when logged in' do
+      before do
+        log_in_as(user)
+      end
+
       context 'when the record.ended_at? is true' do
         it 'redirects to root_path' do
-          log_in_as(user)
           do_request
           expect(response).to redirect_to root_path
         end
       end
 
-      context 'when the record.is_retired? is true' do
+      context 'with auto_retired? is true' do
         it 'redirects to root_path' do
-          log_in_as(user)
-          record.update(is_retired: true)
+          record.update(auto_retired: true)
           do_request
           expect(response).to redirect_to root_path
         end
@@ -127,6 +129,20 @@ RSpec.describe 'Records' do
         record.update(ended_at: Time.zone.now)
         do_request
         expect(response).to redirect_to root_path
+      end
+
+      context 'with auto_retired? is true' do
+        it 'redirects to root_path' do
+          record.update(auto_retired: true)
+          do_request
+          expect(response).to redirect_to root_path
+        end
+
+        it 'has a flash notices record has retired' do
+          record.update(auto_retired: true)
+          do_request
+          expect(flash[:notice]).to eq '記録は無効になっています'
+        end
       end
     end
   end
@@ -196,6 +212,22 @@ RSpec.describe 'Records' do
       it 'redirects to root_path' do
         do_request
         expect(response).to redirect_to root_path
+      end
+
+      context 'with auto_retired? is true' do
+        before do
+          record.update(auto_retired: true)
+        end
+
+        it 'does not updates is_retired true' do
+          do_request
+          expect(record.reload.is_retired).to be_falsey
+        end
+
+        it 'redirects to root_path' do
+          do_request
+          expect(response).to redirect_to root_path
+        end
       end
     end
   end


### PR DESCRIPTION
## やったこと
- DelayedJobを導入して接続後1日経過するレコードを無効にするJobを追加
  - fixed #43 
  - delayd_job_active_recordを導入
    - インフラ強化までは本番環境ではRailsをプロセスを利用することにし、delayed_jobは無効化設定する
  - recordモデルの改良
    - 自動で無効になった場合trueとなるauto_retiredカラムを追加
    - create時にAutoRetireRecordJobを実行するようコールバックを設定（１日後実行）
  - recordsコントローラの改良
    - measure calculate retireアクション前にauto_retired検証
  - AutoRetireRecordJobを追加
    - ジョブ実行時にeneded_atがnilの時以下を実行
      - auto_retiredをtrueにする
      - 記録が無効になった旨をメールする
- 記録無効時のメール設定
  - 店舗名と接続時刻を表示して発信
  - プレビュー設定
- 検証スペック追加
  - AutoRetireRecordJobの実行結果検証
  - auto_retired?がtrueの際のrecordsリクエストの挙動検証

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス