### PR TITLE
RamenShop登録・更新機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
     redirect_to login_url, status: :see_other
   end
 
+  def admin_user
+    redirect_to root_url, status: :see_other, notice: '不正なアクセスです' unless current_user.admin?
+  end
+
   def disable_connect_button
     @show_connect_button = false
   end

--- a/app/controllers/ramen_shops_controller.rb
+++ b/app/controllers/ramen_shops_controller.rb
@@ -1,7 +1,7 @@
 class RamenShopsController < ApplicationController
   before_action :set_ramen_shop, only: %i[show edit update]
   before_action :logged_in_user, only: %i[new edit create update]
-  before_action :admin_user    , only: %i[new edit create update]
+  before_action :admin_user,     only: %i[new edit create update]
 
   def index
     @ramen_shops = RamenShop.all

--- a/app/controllers/ramen_shops_controller.rb
+++ b/app/controllers/ramen_shops_controller.rb
@@ -1,4 +1,8 @@
 class RamenShopsController < ApplicationController
+  before_action :set_ramen_shop, only: %i[show edit update]
+  before_action :logged_in_user, only: %i[new edit create update]
+  before_action :admin_user    , only: %i[new edit create update]
+
   def index
     @ramen_shops = RamenShop.all
 
@@ -9,12 +13,36 @@ class RamenShopsController < ApplicationController
   end
 
   def show
-    @ramen_shop = RamenShop.find(params[:id])
     @records = @ramen_shop.records.order(created_at: 'desc').page(params[:page])
 
     respond_to do |format|
       format.html
       format.json { render json: @ramen_shop.as_json(include: :records) }
+    end
+  end
+
+  def new
+    @ramen_shop = RamenShop.new
+  end
+
+  def edit
+  end
+
+  def create
+    ramen_shop = RamenShop.new(ramen_shop_params)
+
+    if ramen_shop.save
+      redirect_to new_ramen_shop_path, notice: 'saved!'
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @ramen_shop.update(ramen_shop_params)
+      redirect_to ramen_shop_path(@ramen_shop), notice: 'saved!'
+    else
+      render :edit
     end
   end
 
@@ -25,5 +53,15 @@ class RamenShopsController < ApplicationController
 
     @ramen_shops = RamenShop.near([current_lat, current_lng], TARGET_RADIUS)
     render json: @ramen_shops
+  end
+
+  private
+
+  def set_ramen_shop
+    @ramen_shop = RamenShop.find(params[:id])
+  end
+
+  def ramen_shop_params
+    params.require(:ramen_shop).permit(:name, :address)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,8 +74,4 @@ class UsersController < ApplicationController
     flash.alert = '不正なアクセスです'
     redirect_to root_path, status: :see_other
   end
-
-  def admin_user
-    redirect_to root_url, status: :see_other, notice: '不正なアクセスです' unless current_user.admin?
-  end
 end

--- a/app/models/ramen_shop.rb
+++ b/app/models/ramen_shop.rb
@@ -1,10 +1,15 @@
 class RamenShop < ApplicationRecord
   geocoded_by :address
-  after_validation :geocode
+  after_validation :geocode, if: :address_changed?
 
   has_many :records, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :favorite_users, through: :favorites, source: :user
+
+  validates :name, presence: true, uniqueness: { scope: :address }
+  validates :address, presence: true
+  validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }, allow_blank: true
+  validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }, allow_blank: true
 
   def self.ransackable_attributes(_auth_object = nil)
     ['name']

--- a/app/views/ramen_shops/_form.html.erb
+++ b/app/views/ramen_shops/_form.html.erb
@@ -1,0 +1,7 @@
+<%= bootstrap_form_with model: @ramen_shop do |f|%>
+  <%= f.text_field :name %>
+  <%= f.text_field :address %>
+  <div class="d-grid">
+    <%= f.submit yield(:button_text) %>
+  </div>
+<% end %>

--- a/app/views/ramen_shops/edit.html.erb
+++ b/app/views/ramen_shops/edit.html.erb
@@ -1,0 +1,5 @@
+<% provide(:button_text, '更新する') %>
+<h1>店舗更新</h1>
+<div class="col-md-6">
+  <%= render 'form' %>
+</div>

--- a/app/views/ramen_shops/new.html.erb
+++ b/app/views/ramen_shops/new.html.erb
@@ -1,0 +1,5 @@
+<% provide(:button_text, '登録する') %>
+<h1>店舗登録</h1>
+<div class="col-md-6">
+  <%= render 'form' %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
-  resources :ramen_shops, only: [:index, :show] do
+  resources :ramen_shops, only: [:index, :show, :new, :create, :edit, :update] do
     resources :records, only: [:show, :new, :create, :edit, :update], shallow: true do
       member do
         get 'measure'

--- a/db/migrate/20230806231531_change_column_null_and_add_index_to_ramen_shops.rb
+++ b/db/migrate/20230806231531_change_column_null_and_add_index_to_ramen_shops.rb
@@ -1,0 +1,10 @@
+class ChangeColumnNullAndAddIndexToRamenShops < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :ramen_shops, :name, false
+    change_column_null :ramen_shops, :address, false
+    change_column_null :ramen_shops, :latitude, false
+    change_column_null :ramen_shops, :longitude, false
+
+    add_index :ramen_shops, [:name, :address], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_04_123310) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_06_231531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,12 +78,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_04_123310) do
   end
 
   create_table "ramen_shops", force: :cascade do |t|
-    t.string "name"
-    t.string "address"
-    t.float "latitude"
-    t.float "longitude"
+    t.string "name", null: false
+    t.string "address", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name", "address"], name: "index_ramen_shops_on_name_and_address", unique: true
   end
 
   create_table "records", force: :cascade do |t|

--- a/spec/factories/ramen_shops.rb
+++ b/spec/factories/ramen_shops.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     address { '〒101-0023 東京都千代田区神田松永町16' }
     latitude { 35.7000396 }
     longitude { 139.7752222 }
+
+    factory :many_shops do
+      sequence(:name) { |n| "#{n}号ラーメン店" }
+    end
   end
 end

--- a/spec/models/ramen_shop_spec.rb
+++ b/spec/models/ramen_shop_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe RamenShop do
     it 'validates presence of name' do
       ramen_shop.name = nil
       ramen_shop.valid?
-      expect(ramen_shop.errors[:name]).to include("を入力してください")
+      expect(ramen_shop.errors[:name]).to include('を入力してください')
     end
 
     it 'validates presence of address' do
       ramen_shop.address = nil
       ramen_shop.valid?
-      expect(ramen_shop.errors[:address]).to include("を入力してください")
+      expect(ramen_shop.errors[:address]).to include('を入力してください')
     end
 
     it 'validates uniqueness of name scoped to address' do
@@ -31,19 +31,19 @@ RSpec.describe RamenShop do
       ramen_shop.name = existing_shop.name
       ramen_shop.address = existing_shop.address
       ramen_shop.valid?
-      expect(ramen_shop.errors[:name]).to include("はすでに存在します")
+      expect(ramen_shop.errors[:name]).to include('はすでに存在します')
     end
 
     it 'validates numericality of latitude' do
       ramen_shop.latitude = 91
       ramen_shop.valid?
-      expect(ramen_shop.errors[:latitude]).to include("は90以下の値にしてください")
+      expect(ramen_shop.errors[:latitude]).to include('は90以下の値にしてください')
     end
 
     it 'validates numericality of longitude' do
       ramen_shop.longitude = 181
       ramen_shop.valid?
-      expect(ramen_shop.errors[:longitude]).to include("は180以下の値にしてください")
+      expect(ramen_shop.errors[:longitude]).to include('は180以下の値にしてください')
     end
   end
 
@@ -71,14 +71,14 @@ RSpec.describe RamenShop do
         ramen_shop.reload
       end
 
-      it 'returns true' do
-        expect(ramen_shop.favorited_by?(user)).to be_truthy
+      it 'is favorited by user' do
+        expect(ramen_shop).to be_favorited_by(user)
       end
     end
 
     context 'when the user has not favorited the ramen shop' do
-      it 'returns false' do
-        expect(ramen_shop.favorited_by?(user)).to be_falsey
+      it 'is not favorited by user' do
+        expect(ramen_shop).to_not be_favorited_by(user)
       end
     end
   end

--- a/spec/models/ramen_shop_spec.rb
+++ b/spec/models/ramen_shop_spec.rb
@@ -1,25 +1,85 @@
 require 'rails_helper'
 
 RSpec.describe RamenShop do
-  it 'is valid with name, address, latitude and longitude' do
-    ramen_shop = described_class.new(
-      name: '家系らーめん 武将家 外伝',
-      address: '〒101-0023 東京都千代田区神田松永町16',
-      latitude: 35.7000396,
-      longitude: 139.7752222
-    )
-    expect(ramen_shop).to be_valid
+  let(:ramen_shop) { build(:ramen_shop) }
+
+  describe 'Validations' do
+    it 'is valid with name, address, latitude and longitude' do
+      ramen_shop = described_class.new(
+        name: '家系らーめん 武将家 外伝',
+        address: '〒101-0023 東京都千代田区神田松永町16',
+        latitude: 35.7000396,
+        longitude: 139.7752222
+      )
+      expect(ramen_shop).to be_valid
+    end
+
+    it 'validates presence of name' do
+      ramen_shop.name = nil
+      ramen_shop.valid?
+      expect(ramen_shop.errors[:name]).to include("を入力してください")
+    end
+
+    it 'validates presence of address' do
+      ramen_shop.address = nil
+      ramen_shop.valid?
+      expect(ramen_shop.errors[:address]).to include("を入力してください")
+    end
+
+    it 'validates uniqueness of name scoped to address' do
+      existing_shop = create(:ramen_shop)
+      ramen_shop.name = existing_shop.name
+      ramen_shop.address = existing_shop.address
+      ramen_shop.valid?
+      expect(ramen_shop.errors[:name]).to include("はすでに存在します")
+    end
+
+    it 'validates numericality of latitude' do
+      ramen_shop.latitude = 91
+      ramen_shop.valid?
+      expect(ramen_shop.errors[:latitude]).to include("は90以下の値にしてください")
+    end
+
+    it 'validates numericality of longitude' do
+      ramen_shop.longitude = 181
+      ramen_shop.valid?
+      expect(ramen_shop.errors[:longitude]).to include("は180以下の値にしてください")
+    end
   end
 
-  it 'is valid with Bot' do
-    ramen_shop = create(:ramen_shop)
-    expect(ramen_shop).to be_valid
+  describe 'Associations' do
+    it 'has many records' do
+      expect(ramen_shop).to respond_to(:records)
+    end
+
+    it 'has many favorites' do
+      expect(ramen_shop).to respond_to(:favorites)
+    end
+
+    it 'has many favorite_users through favorites' do
+      expect(ramen_shop).to respond_to(:favorite_users)
+    end
   end
 
-  it 'returns true when favorited by the shop' do
-    user = create(:user)
-    ramen_shop = create(:ramen_shop)
-    user.add_favorite(ramen_shop)
-    expect(ramen_shop).to be_favorited_by(user)
+  describe '#favorited_by?' do
+    let(:ramen_shop) { create(:ramen_shop) }
+    let(:user) { create(:user) }
+
+    context 'when the user has favorited the ramen shop' do
+      before do
+        ramen_shop.favorites.create(user: user)
+        ramen_shop.reload
+      end
+
+      it 'returns true' do
+        expect(ramen_shop.favorited_by?(user)).to be_truthy
+      end
+    end
+
+    context 'when the user has not favorited the ramen shop' do
+      it 'returns false' do
+        expect(ramen_shop.favorited_by?(user)).to be_falsey
+      end
+    end
   end
 end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Record do
     end
 
     it 'returns the most recent first' do
-      create_list(:many_records, 10, user: user)
-      expect(create(:most_recent, user: user)).to eq described_class.first
+      create_list(:many_records, 10, user: user, ramen_shop: ramen_shop)
+      most_recent_record = create(:most_recent, user: user, ramen_shop: ramen_shop)
+      expect(most_recent_record).to eq described_class.first
     end
 
     it 'is valid with a 4.2 MB image' do

--- a/spec/requests/ramen_shops_spec.rb
+++ b/spec/requests/ramen_shops_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe "RamenShops", type: :request do
+  let(:ramen_shop) { create(:ramen_shop) }
+  let(:non_admin) { create(:other_user) }
+  let(:admin) { create(:user) }
+
+
+  shared_examples 'when not logged in' do
+    it 'redirects to login_path' do
+      do_request
+      expect(response).to redirect_to login_path
+    end
+  end
+
+  shared_examples 'as a non-admin' do
+    it 'redirects to root_path' do
+      log_in_as non_admin
+      do_request
+      expect(response).to redirect_to root_path
+    end
+  end
+
+  describe "GET /ramen_shops/new #new" do
+    let(:do_request) { get new_ramen_shop_path }
+
+    it_behaves_like 'when not logged in'
+    it_behaves_like 'as a non-admin'
+
+    it 'returns new form when logged in as an admin' do
+      log_in_as admin
+      do_request
+      expect(response.body).to include '<h1>店舗登録</h1>'
+    end
+  end
+
+  describe "GET /ramen_shops/:id/edit #edit" do
+    let(:do_request) { get edit_ramen_shop_path(ramen_shop) }
+
+    it_behaves_like 'when not logged in'
+    it_behaves_like 'as a non-admin'
+
+    it 'returns edit form when logged in as an admin' do
+      log_in_as admin
+      do_request
+      expect(response.body).to include '<h1>店舗更新</h1>'
+    end
+  end
+
+  describe "POST /ramen_shops #create" do
+    let(:do_request) { post ramen_shops_path, params: ramen_shop_params }
+    let(:ramen_shop_params) { { ramen_shop: attributes_for(:ramen_shop) } }
+
+    it_behaves_like 'when not logged in'
+    it_behaves_like 'as a non-admin'
+
+    it 'creates ramen_shop when logged in as an admin' do
+      log_in_as admin
+      expect {
+        do_request
+      }.to change(RamenShop, :count).by(1)
+    end
+  end
+
+  describe "PATCH /ramen_shops/:id #update" do
+    let(:do_request) { patch ramen_shop_path(ramen_shop), params: ramen_shop_params }
+    let(:ramen_shop_params) { { ramen_shop: attributes_for(:ramen_shop, name: 'ラーメン店') } }
+
+    it_behaves_like 'when not logged in'
+    it_behaves_like 'as a non-admin'
+
+    it 'updates ramen_shop when logged in as an admin' do
+      log_in_as admin
+      do_request
+      expect(ramen_shop.reload.name).to eq 'ラーメン店'
+    end
+  end
+end

--- a/spec/requests/ramen_shops_spec.rb
+++ b/spec/requests/ramen_shops_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe "RamenShops", type: :request do
+RSpec.describe 'RamenShops' do
   let(:ramen_shop) { create(:ramen_shop) }
   let(:non_admin) { create(:other_user) }
   let(:admin) { create(:user) }
-
 
   shared_examples 'when not logged in' do
     it 'redirects to login_path' do
@@ -21,7 +20,7 @@ RSpec.describe "RamenShops", type: :request do
     end
   end
 
-  describe "GET /ramen_shops/new #new" do
+  describe 'GET /ramen_shops/new #new' do
     let(:do_request) { get new_ramen_shop_path }
 
     it_behaves_like 'when not logged in'
@@ -34,7 +33,7 @@ RSpec.describe "RamenShops", type: :request do
     end
   end
 
-  describe "GET /ramen_shops/:id/edit #edit" do
+  describe 'GET /ramen_shops/:id/edit #edit' do
     let(:do_request) { get edit_ramen_shop_path(ramen_shop) }
 
     it_behaves_like 'when not logged in'
@@ -47,7 +46,7 @@ RSpec.describe "RamenShops", type: :request do
     end
   end
 
-  describe "POST /ramen_shops #create" do
+  describe 'POST /ramen_shops #create' do
     let(:do_request) { post ramen_shops_path, params: ramen_shop_params }
     let(:ramen_shop_params) { { ramen_shop: attributes_for(:ramen_shop) } }
 
@@ -62,7 +61,7 @@ RSpec.describe "RamenShops", type: :request do
     end
   end
 
-  describe "PATCH /ramen_shops/:id #update" do
+  describe 'PATCH /ramen_shops/:id #update' do
     let(:do_request) { patch ramen_shop_path(ramen_shop), params: ramen_shop_params }
     let(:ramen_shop_params) { { ramen_shop: attributes_for(:ramen_shop, name: 'ラーメン店') } }
 

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Favorites' do
   let(:user) { create(:user) }
-  let(:ramen_shops) { create_list(:ramen_shop, 5) }
+  let(:ramen_shops) { create_list(:many_shops, 5) }
 
   before do
     ramen_shops.each do |ramen_shop|

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe 'Users' do
 
     let(:user) { create(:user) }
     let(:other_user) { create(:other_user) }
+    let(:ramen_shop) { create(:ramen_shop) }
 
     it 'shows edit_user_path when vist current_user path' do
       log_in_as(user)
@@ -106,8 +107,8 @@ RSpec.describe 'Users' do
     end
 
     it 'shows their profile and records' do
-      create_list(:many_records, 15, user: user)
-      create(:record, user: user, is_retired: true)
+      create_list(:many_records, 15, user: user, ramen_shop: ramen_shop)
+      create(:record, user: user, is_retired: true, ramen_shop: ramen_shop)
 
       visit user_path(user)
       expect(find('h1')).to have_content user.name


### PR DESCRIPTION
## やったこと
- RamenShopモデルの改良
  - 各カラムにnull falseを追加
  - nameとaddressの複合インデックスを追加
  - geocodeはaddress変更時のみに実施するよう変更
  - 各カラムのバリデーション設定
- ramen_shopsコントローラの改良
  - adminユーザーのみcreate, update可能にした
- ramen_shops登録・更新フォームの追加
- スペックの追加・改良
  - モデルスペックの追加
  - リクエストスペックの追加

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス