### PR TITLE
一覧表示内容の変更とデザインの改善

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -308,10 +308,6 @@ section {
   }
 }
 
-.shop-address {
-  font-size: 0.8rem;
-  color: #7a7a7a;
-}
 
 .shops {
   a {
@@ -319,6 +315,10 @@ section {
     .shop-info {
       h5 {
         margin-bottom: 0;
+      }
+      .shop-address {
+        font-size: 0.8rem;
+        color: #7a7a7a;
       }
     }
     .recent-record {
@@ -329,4 +329,8 @@ section {
       }
     }
   }
+}
+
+.small-milliseconds {
+  font-size: 1rem;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -300,3 +300,10 @@ div[data-controller="line-status"] {
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }
+
+
+section {
+  h2 {
+    font-weight: 600;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,10 @@
 @import "bootstrap";
 @import 'fonts';
 /* universal */
+body {
+  font-family: 'Noto Sans JP', sans-serif;
+}
+
 .navbar-brand {
   font-family: '851letrogo';
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -307,3 +307,26 @@ section {
     font-weight: 600;
   }
 }
+
+.shop-address {
+  font-size: 0.8rem;
+  color: #7a7a7a;
+}
+
+.shops {
+  a {
+    text-decoration: none;
+    .shop-info {
+      h5 {
+        margin-bottom: 0;
+      }
+    }
+    .recent-record {
+      .no-record {
+        small {
+          color:#4e4a4a;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -4,3 +4,10 @@
   font-weight: normal;
   font-style: normal;
 }
+
+@font-face {
+  font-family: 'Sato Sans JP';
+  src: url('NotoSansJP-VariableFont_wght.ttf');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,8 +4,8 @@ class HomeController < ApplicationController
 
   def index
     @search = RamenShop.ransack(params[:q])
-    @search.sorts = 'id desc' if @search.sorts.empty?
-    @ramen_shops = @search.result.page(params[:page])
+    @ranking_records = Record.unscoped.where(is_retired: false, auto_retired: false).order('wait_time DESC').limit(5)
+    @new_records = Record.where(is_retired: false, auto_retired: false).take(5)
   end
 
   def search

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,27 @@
 class HomeController < ApplicationController
   before_action :logged_in_user, only: %i[search]
+  before_action :set_search, only: %i[index record_ranking new_records]
   before_action :disable_connect_button, only: %i[search]
 
   def index
-    @search = RamenShop.ransack(params[:q])
     @ranking_records = Record.unscoped.where(is_retired: false, auto_retired: false).order('wait_time DESC').limit(5)
     @new_records = Record.where(is_retired: false, auto_retired: false).take(5)
   end
 
+  def record_ranking
+    @records = Record.unscoped.where(is_retired: false, auto_retired: false).page(params[:page])
+  end
+
+  def new_records
+    @records = Record.where(is_retired: false, auto_retired: false).page(params[:page])
+  end
+
   def search
+  end
+
+  private
+
+  def set_search
+    @search = RamenShop.ransack(params[:q])
   end
 end

--- a/app/controllers/ramen_shops_controller.rb
+++ b/app/controllers/ramen_shops_controller.rb
@@ -4,7 +4,9 @@ class RamenShopsController < ApplicationController
   before_action :admin_user,     only: %i[new edit create update]
 
   def index
-    @ramen_shops = RamenShop.all
+    @search = RamenShop.ransack(params[:q])
+    @search.sorts = 'id desc' if @search.sorts.empty?
+    @ramen_shops = @search.result.page(params[:page])
 
     respond_to do |format|
       format.html

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,9 +10,19 @@ module ApplicationHelper
     return unless wait_time
 
     hours, remainder = wait_time.divmod(3600)
-    minutes, seconds = remainder.divmod(60)
-    format('%<hours>02d:%<minutes>02d:%<seconds>02d', hours: hours, minutes: minutes, seconds: seconds)
+    minutes, remainder_seconds = remainder.divmod(60)
+    seconds, milliseconds = remainder_seconds.divmod(1)
+    milliseconds = (milliseconds * 1000).round
+
+    formatted_time = format('%<hours>02d:%<minutes>02d:%<seconds>02d',
+                            hours: hours,
+                            minutes: minutes,
+                            seconds: seconds)
+    formatted_milliseconds = format('.%<milliseconds>03d', milliseconds: milliseconds)
+
+    tag.div tag.span(formatted_time) + tag.span(formatted_milliseconds, class: 'small-milliseconds')
   end
+
 
   def turbo_stream_flash
     turbo_stream.update 'flash', partial: 'flash'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,7 @@ module ApplicationHelper
     datetime.strftime("%Y/%m/%d(#{wdays[datetime.wday]}) %H:%M")
   end
 
+  # rubocop:disable Metrics/MethodLength
   def format_wait_time(wait_time)
     return unless wait_time
 
@@ -22,7 +23,7 @@ module ApplicationHelper
 
     tag.div tag.span(formatted_time) + tag.span(formatted_milliseconds, class: 'small-milliseconds')
   end
-
+  # rubocop:enable Metrics/MethodLength
 
   def turbo_stream_flash
     turbo_stream.update 'flash', partial: 'flash'

--- a/app/helpers/line_statuses_helper.rb
+++ b/app/helpers/line_statuses_helper.rb
@@ -2,24 +2,19 @@ module LineStatusesHelper
   def line_type_badge(line_status)
     case line_status.line_type
     when 'seated'
-      content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-green')
+      content_tag(:span, line_status_content(line_status), class: 'type-badge badge-green')
     when 'inside_the_store'
-      content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-yellow')
+      content_tag(:span, line_status_content(line_status), class: 'type-badge badge-yellow')
     when 'outside_the_store'
-      content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-red')
+      content_tag(:span, line_status_content(line_status), class: 'type-badge badge-red')
     end
   end
 
-  def status_badge_class(line_type)
-    case line_type
-    when 'inside_the_store'
-      'type-badge badge-yellow'
-    when 'outside_the_store'
-      'type-badge badge-red'
-    when 'seated'
-      'type-badge badge-green'
+  def line_status_content(line_status)
+    if line_status.line_type == 'seated'
+      "#{line_status.line_type_i18n}"
     else
-      'bg-secondary'
+      "#{line_status.line_type_i18n} - #{line_status.line_number}人"
     end
   end
 end

--- a/app/helpers/line_statuses_helper.rb
+++ b/app/helpers/line_statuses_helper.rb
@@ -12,7 +12,7 @@ module LineStatusesHelper
 
   def line_status_content(line_status)
     if line_status.line_type == 'seated'
-      "#{line_status.line_type_i18n}"
+      line_status.line_type_i18n.to_s
     else
       "#{line_status.line_type_i18n} - #{line_status.line_number}人"
     end

--- a/app/helpers/line_statuses_helper.rb
+++ b/app/helpers/line_statuses_helper.rb
@@ -9,4 +9,17 @@ module LineStatusesHelper
       content_tag(:span, line_status.line_type_i18n, class: 'type-badge badge-red')
     end
   end
+
+  def status_badge_class(line_type)
+    case line_type
+    when 'inside_the_store'
+      'type-badge badge-yellow'
+    when 'outside_the_store'
+      'type-badge badge-red'
+    when 'seated'
+      'type-badge badge-green'
+    else
+      'bg-secondary'
+    end
+  end
 end

--- a/app/views/home/_record.html.erb
+++ b/app/views/home/_record.html.erb
@@ -1,0 +1,30 @@
+<div class="d-flex text-body-secondary pt-3">
+  <%= link_to avatar_for(record.user, :small), record.user %>
+  <div class="pb-3 mb-0 small lh-sm border-bottom w-100">
+    <div class="mb-1 d-flex w-100 justify-content-between">
+      <span class="d-block text-gray-dark"><%= shop_or_user(record, name) %></span>
+      <small><%= format_datetime record.created_at %></small>
+    </div>
+    <div class="d-flex justify-content-between align-items-end">
+      <div>
+        <div class="record-value d-flex align-items-center">
+          <span class="fs-2 me-2"><%= format_wait_time record.wait_time %></span>
+          <% if record.is_retired? %>
+            <span class="badge rounded-pill bg-secondary">リタイア</span>
+          <% else %>
+            <span class="badge rounded-pill bg-primary">ちゃくどん</span>
+          <% end %>
+        </div>
+        <% if record.comment %>
+          <p class="mb-1">ひとこと: <%= record.comment %></p>
+        <% end %>
+        <% if record.image.attached? %>
+          <%= image_tag record.image.variant(:display) %>
+        <% end %>
+      </div>
+      <div class="d-flex justify-content-end">
+        <%= link_to '詳細', record_path(record) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,7 @@
     <%= render @ranking_records, name: :ramen_shop %>
   </div>
   <div class="more d-grid gap-2">
-    <%= link_to 'もっとみる', '#', class: 'btn btn-outline-dark' %>
+    <%= link_to 'もっとみる', ranking_path, class: 'btn btn-outline-dark' %>
   </div>
 </section>
 <section class="new-records mb-3">
@@ -14,6 +14,6 @@
     <%= render @new_records, name: :ramen_shop %>
   </div>
   <div class="more d-grid gap-2">
-    <%= link_to 'もっとみる', '#', class: 'btn btn-outline-dark' %>
+    <%= link_to 'もっとみる', new_records_path, class: 'btn btn-outline-dark' %>
   </div>
 </section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,19 @@
-<%= render template: "ramen_shops/index" %>
+<%= render 'shared/search_form' %>
+<section class="ranking mb-4">
+  <h2 class="d-flex justify-content-center py-2 mt-3">ちゃくどんランキング</h2>
+  <div class="records pb-2">
+    <%= render @ranking_records, name: :ramen_shop %>
+  </div>
+  <div class="more d-grid gap-2">
+    <%= link_to 'もっとみる', '#', class: 'btn btn-outline-dark' %>
+  </div>
+</section>
+<section class="new-records mb-3">
+  <h2 class="d-flex justify-content-center py-2 mt-3">新着ちゃくどん</h2>
+  <div class="records pb-2">
+    <%= render @new_records, name: :ramen_shop %>
+  </div>
+  <div class="more d-grid gap-2">
+    <%= link_to 'もっとみる', '#', class: 'btn btn-outline-dark' %>
+  </div>
+</section>

--- a/app/views/home/new_records.html.erb
+++ b/app/views/home/new_records.html.erb
@@ -1,0 +1,10 @@
+<%= render 'shared/search_form' %>
+<section class="new-records mb-3">
+  <h2 class="d-flex justify-content-center py-2 mt-3">新着ちゃくどん</h2>
+  <div class="records pb-2">
+    <%= render @records, name: :ramen_shop %>
+  </div>
+  <div>
+    <%= paginate @records %>
+  </div>
+</section>

--- a/app/views/home/record_ranking.html.erb
+++ b/app/views/home/record_ranking.html.erb
@@ -1,0 +1,10 @@
+<%= render 'shared/search_form' %>
+<section class="ranking mb-4">
+  <h2 class="d-flex justify-content-center py-2 mt-3">ちゃくどんランキング</h2>
+  <div class="records pb-2">
+    <%= render @records, name: :ramen_shop %>
+  </div>
+  <div>
+    <%= paginate @records %>
+  </div>
+</section>

--- a/app/views/line_statuses/_line_status.html.erb
+++ b/app/views/line_statuses/_line_status.html.erb
@@ -9,11 +9,8 @@
       <div class="d-flex justify-content-between align-items-end">
         <div>
           <p class="mb-1"><%= line_type_badge(line_status) %></p>
-          <% unless line_status.seated? %>
-            <p class="mb-1">待ち行列: <%= line_status.line_number %></p>
-          <% end %>
           <% if line_status.comment.present? %>
-            <p class="mb-1">ひとこと: <%= line_status.comment %></p>
+            <p class="mb-1"><%= line_status.comment %></p>
           <% end %>
           <% if line_status.image.attached? %>
             <%= image_tag line_status.image.variant(:display) %>

--- a/app/views/ramen_shops/_ramen_shop.html.erb
+++ b/app/views/ramen_shops/_ramen_shop.html.erb
@@ -9,10 +9,8 @@
       <div class="record-line_status d-flex align-items-center">
         <small class='badge bg-dark me-2'>New</small>
         <span class="fs-2 me-2"><%= format_wait_time last_record.wait_time %></span>
-        <% last_status = last_record.line_statuses.last %>
-        <small class="<%= status_badge_class(last_status.line_type) %>">
-          <%= last_status.line_type_i18n %> - <%= last_status.line_number %>人
-        </small>
+        <% first_status = last_record.line_statuses.first %>
+        <%= line_type_badge(first_status) %>
       </div>
     <% else %>
       <div class="no-record">

--- a/app/views/ramen_shops/_ramen_shop.html.erb
+++ b/app/views/ramen_shops/_ramen_shop.html.erb
@@ -1,13 +1,23 @@
-<div class="row py-2 border-top">
-  <div class="col-4 my-auto">
-    <%= ramen_shop.name %>
+<a href="<%= ramen_shop_path(ramen_shop) %>" class="list-group-item-action py-2 border-bottom">
+  <div class="shop-info pt-2">
+    <h5><%= ramen_shop.name %></h5>
+    <small class="mb-1 shop-address"><%= ramen_shop.address %></small>
   </div>
-  <div class="col-4 my-auto">
-    <%= ramen_shop.address %>
+  <div class="recent-record">
+    <% last_record = ramen_shop.records.first %>
+    <% if last_record %>
+      <div class="record-line_status d-flex align-items-center">
+        <small class='badge bg-dark me-2'>New</small>
+        <span class="fs-2 me-2"><%= format_wait_time last_record.wait_time %></span>
+        <% last_status = last_record.line_statuses.last %>
+        <small class="<%= status_badge_class(last_status.line_type) %>">
+          <%= last_status.line_type_i18n %> - <%= last_status.line_number %>人
+        </small>
+      </div>
+    <% else %>
+      <div class="no-record">
+        <small class='ms-2'>まだ記録がありません</small>
+      </div>
+    <% end %>
   </div>
-  <div class="col-4">
-    <div class="d-flex justify-content-end">
-      <%= link_to 'みてみる', ramen_shop_path(ramen_shop), class: "btn btn-sm btn-outline-primary me-2" %>
-    </div>
-  </div>
-</div>
+</a>

--- a/app/views/ramen_shops/index.html.erb
+++ b/app/views/ramen_shops/index.html.erb
@@ -1,29 +1,10 @@
-<div class="card shadow mt-3">
-  <div class="card-header">
-    <%= tag.span("検索条件") %>
-  </div>
-  <div class="card-body">
-    <%= search_form_for @search, url: root_path  do |f| %>
-      <div class="row g3 mb-3">
-        <div class="col-12 col-sm-6">
-          <%= f.search_field :name_cont, placeholder: "店名で検索", class: "form-control" %>
-        </div>
-        <div class="col-12 col-sm-6 d-flex align-items-end">
-          <%= button_tag "検索", class: "btn btn-primary me-1" %>
-          <%= link_to "リセット", root_path, class: "btn btn-outline-secondary" %>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>
-<div class="card shadow mt-3">
-  <div class="card-header">
-    <%= tag.span("一覧") %>
-  </div>
-  <div class="card-body mx-3">
+<%= render 'shared/search_form' %>
+<section class="shops mb-4">
+  <h2 class="d-flex justify-content-center py-2 mt-3">店舗一覧</h2>
+  <div class="records list-group pb-2">
     <%= render @ramen_shops %>
-    <div class="d-flex justify-content-end mt-3">
-      <%= paginate @ramen_shops %>
-    </div>
   </div>
-</div>
+  <div class="d-flex justify-content-end mt-3">
+    <%= paginate @ramen_shops %>
+  </div>
+</section>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,5 +1,5 @@
 <section class="search mb-4">
-  <h2 class="d-flex justify-content-center py-2 mt-3">ちゃくどんを検索</h2>
+  <h2 class="d-flex justify-content-center py-2 mt-3">ラーメン店を探す</h2>
   <%= search_form_for @search, url: ramen_shops_path do |f| %>
     <div class="input-group">
       <%= f.search_field :name_cont, placeholder: 'ラーメン店を入力...', class: "form-control" %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,9 @@
+<section class="search mb-4">
+  <h2 class="d-flex justify-content-center py-2 mt-3">ちゃくどんを検索</h2>
+  <%= search_form_for @search, url: ramen_shops_path do |f| %>
+    <div class="input-group">
+      <%= f.search_field :name_cont, placeholder: 'ラーメン店を入力...', class: "form-control" %>
+      <%= f.submit "検索", class: "btn btn-outline-dark" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/users/favorite_shops.html.erb
+++ b/app/views/users/favorite_shops.html.erb
@@ -13,12 +13,14 @@
 </aside>
 <div class="col-md-8">
   <% if @ramen_shops.any? %>
-    <div class="my-3 p-3 bg-body rounded shadow-sm">
-    <h6 class="border-bottom pb-2 mb-0"><%= tag.span("お気に入り店 #{@user.favorite_shops.count}") %></h6>
-    <%= render @ramen_shops %>
-    <div class="d-flex justify-content-end mt-3">
-      <%= paginate @ramen_shops %>
+    <div class="shops my-3 p-3 bg-body rounded shadow-sm">
+      <h6 class="border-bottom pb-2 mb-0"><%= tag.span("お気に入り店 #{@user.favorite_shops.count}") %></h6>
+      <div class="list-group">
+        <%= render @ramen_shops %>
+      </div>
+      <div class="d-flex justify-content-center mt-3">
+        <%= paginate @ramen_shops %>
+      </div>
     </div>
-  </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root 'home#index'
   get '/about', to: 'statics#about'
+  get '/ranking', to: 'home#record_ranking'
+  get '/new_records', to: 'home#new_records'
   get '/search', to: 'home#search'
   get '/near_shops', to: 'ramen_shops#near_shops'
   get '/signup', to: 'users#new'

--- a/spec/support/format_helper.rb
+++ b/spec/support/format_helper.rb
@@ -1,0 +1,22 @@
+module FormatSupport
+  module System
+    def format_wait_time_helper(wait_time)
+      return unless wait_time
+
+      hours, remainder = wait_time.divmod(3600)
+      minutes, remainder_seconds = remainder.divmod(60)
+      seconds, milliseconds = remainder_seconds.divmod(1)
+      milliseconds = (milliseconds * 1000).round
+
+      format('%<hours>02d:%<minutes>02d:%<seconds>02d.%<milliseconds>03d',
+             hours: hours,
+             minutes: minutes,
+             seconds: seconds,
+             milliseconds: milliseconds)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include FormatSupport::System, type: :system
+end

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Favorites' do
     visit favorites_by_user_path(user)
     expect(page).to have_content 'お気に入り店 5'
     user.favorite_shops.each do |shop|
-      expect(page).to have_link 'みてみる', href: ramen_shop_path(shop)
+      expect(page).to have_link href: ramen_shop_path(shop)
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Users' do
 
       user.records.page(1).each do |record|
         expect(page).to have_content format_datetime(record.created_at)
-        expect(page).to have_content format_wait_time(record.wait_time)
+        expect(page).to have_content format_wait_time_helper(record.wait_time)
 
         if record.is_retired?
           expect(page).to have_content 'リタイア'


### PR DESCRIPTION
## やったこと
- Homeコントローラの改善
  - indexアクションで表示する内容を店舗一覧から記録一覧へ変更
  - 記録のランキングを表示するrecord_rankingアクションを追加
  - 最新記録を表示するnew_recordsアクションを追加
- ramen_shopsコントローラは検索したラーメン一覧を表示するよう変更
- ヘルパーの改善
  - 小数点第３桁まで記録を表示するようformat_wait_timeヘルパーを変更
  - 待ち状態と待ち行列数をバッジ表示するようline_type_badgeヘルパーを変更
- ビューの追加・改善
  - 記録一覧用パーシャルとして_recor.html.erbを追加
  - ラーメン店一覧用パーシャルの_ramen_shop.html.erbで最新記録を表示するよう改善
  - ラーメン店検索セクションを再利用できるようパーシャルへ切り出し
- Noto Sans JPフォントを導入
- スペックの改善
  - spec用ヘルパーとしてformat_wait_time_helperを追加
  - ビュー変更に対応してsystemスペック修正

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス