### PR TITLE
ラーメン店のスクレイピングタスクを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.3)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
@@ -104,7 +104,7 @@ GEM
       actionpack (>= 6.0)
       activemodel (>= 6.0)
     builder (3.2.4)
-    capybara (3.39.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -196,7 +196,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_magick (4.12.0)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     minitest (5.18.0)
     msgpack (1.7.0)
     net-imap (0.3.4)
@@ -209,9 +209,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.14.2-arm64-darwin)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-linux)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -219,11 +219,11 @@ GEM
       racc
     pg (1.4.6)
     popper_js (2.11.7)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (5.6.5)
       nio4r (~> 2.0)
-    racc (1.6.2)
-    rack (2.2.6.4)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
@@ -258,10 +258,10 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.1)
     reline (0.3.3)
       io-console (~> 0.5)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.2)
@@ -321,7 +321,7 @@ GEM
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    selenium-webdriver (4.8.6)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -349,10 +349,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -405,7 +401,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,1 @@
+require File.expand_path('config/environment', __dir__)

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -1,0 +1,6 @@
+class DocumentFetcher
+  def self.fetch_document_from_url(url)
+    html_content = URI.parse(url).read
+    Nokogiri::HTML(html_content)
+  end
+end

--- a/app/services/shop_info_extractor.rb
+++ b/app/services/shop_info_extractor.rb
@@ -1,0 +1,42 @@
+class ShopInfoExtractor
+  class << self
+    def extract_shop_links(document)
+      document.xpath('//div[@class="ranks"]//table[@class="rank"]//span[@class="name"]/a/@href').map(&:text)
+    end
+
+    def extract_shop_info(document)
+      document.xpath('//*[@id="shop-data-table"]').map do |node|
+        extract_individual_shop_info(node)
+      end
+    end
+
+    private
+
+    def extract_individual_shop_info(node)
+      shop_name = extract_text(node, '//th[text()="店名"]/following-sibling::td')
+      prefecture, city, full_address = extract_address_info(node)
+      operation_hours = extract_text(node, '//th[text()="営業時間"]/following-sibling::td')
+      closing_days = extract_text(node, '//th[text()="定休日"]/following-sibling::td')
+      today = Time.zone.today
+
+      [shop_name, prefecture, city, full_address, operation_hours, closing_days, today]
+    end
+
+    def extract_address_info(node)
+      address_node = node.at_xpath('//th[text()="住所"]/following-sibling::td/span')
+      prefecture = address_node.at_xpath('a[1]').text
+      city = address_node.at_xpath('a[2]').text
+      full_address = normalize_full_address(address_node.text)
+
+      [prefecture, city, full_address]
+    end
+
+    def normalize_full_address(address)
+      address.gsub(/〒\d+-\d+ /, '').gsub(/このお店は「.+」から移転しました。/, '')
+    end
+
+    def extract_text(node, xpath)
+      node.xpath(xpath).text.strip
+    end
+  end
+end

--- a/app/services/shop_info_inserter.rb
+++ b/app/services/shop_info_inserter.rb
@@ -1,0 +1,45 @@
+class ShopInfoInserter
+  class << self
+    # rubocop:disable Rails/Output
+    def insert_unique_shops(shop_infos)
+      shop_infos.each_with_object([]) do |info, unique_shops|
+        shop_name, _, _, full_address, = info
+
+        if shop_already_exists?(shop_name, full_address)
+          puts "'#{shop_name}' already exists."
+        else
+          insert_shop(shop_name, full_address, info, unique_shops)
+        end
+      end
+    end
+
+    def append_shop_info_to_csv(csv_path, valid_shop_info, last_id = nil)
+      last_id ||= last_id_from_csv(csv_path)
+      CSV.open(csv_path, 'a') do |csv|
+        valid_shop_info.each_with_index do |info, index|
+          csv << [last_id + index + 1, *info]
+        end
+      end
+    end
+
+    def last_id_from_csv(file_name)
+      last_line = CSV.readlines(file_name).last
+      return 0 unless last_line
+
+      last_line.first.to_i
+    end
+
+    private
+
+    def shop_already_exists?(shop_name, full_address)
+      RamenShop.exists?(name: shop_name, address: full_address)
+    end
+
+    def insert_shop(shop_name, full_address, info, unique_shops)
+      RamenShop.create(name: shop_name, address: full_address)
+      unique_shops << info
+      puts "'#{shop_name}' was inserted."
+    end
+    # rubocop:enable Rails/Output
+  end
+end

--- a/app/services/url_manager.rb
+++ b/app/services/url_manager.rb
@@ -1,0 +1,33 @@
+class UrlManager
+  BASE_URL = 'https://ramendb.supleks.jp'.freeze
+  LAST_PAGE_FILE = 'lib/tasks/last_page.txt'.freeze
+  LAST_LINK_FILE = 'lib/tasks/last_link.txt'.freeze
+
+  class << self
+    def retrieve_last_shop_url
+      File.read(LAST_LINK_FILE).chomp
+    end
+
+    def save_last_link(link)
+      File.write(LAST_LINK_FILE, link)
+    end
+
+    def build_url(path)
+      BASE_URL + path
+    end
+  end
+
+  def initialize(resume_option)
+    @resume_option = resume_option
+  end
+
+  def retrieve_target_url
+    return File.read(LAST_PAGE_FILE).chomp if @resume_option && File.exist?(LAST_PAGE_FILE)
+
+    "#{BASE_URL}/rank"
+  end
+
+  def save_last_page(target_url)
+    File.write(LAST_PAGE_FILE, target_url)
+  end
+end

--- a/lib/tasks/scraping.thor
+++ b/lib/tasks/scraping.thor
@@ -1,0 +1,101 @@
+require 'thor'
+require 'nokogiri'
+require 'open-uri'
+require 'csv'
+
+class Scraping < Thor
+  WAIT_SECONDS = 30
+
+  desc 'scrape_ramen_shops', '各ラーメン店へアクセスして店の情報を取得する'
+  option :limit, type: :numeric, default: 10, desc: '取得するラーメン店の最大数'
+  option :resume, type: :boolean, default: true, desc: '前回の続きからスクレイピングを再開'
+
+  def scrape_ramen_shops
+    initialize_scraping
+    loop do
+      break if reached_limit?
+
+      process_current_target_url
+      update_target_url
+    end
+  end
+
+  desc 'execute SHOP_URL', 'スクレイピングしてユニークなShopをインサート・CSV出力'
+  def execute(shop_url)
+    document = DocumentFetcher.fetch_document_from_url(shop_url)
+    shop_infos = ShopInfoExtractor.extract_shop_info(document)
+
+    valid_shop_info = ShopInfoInserter.insert_unique_shops(shop_infos)
+    ShopInfoInserter.append_shop_info_to_csv('db/imports/ramen_shop_master.csv', valid_shop_info)
+  end
+
+  private
+
+  def initialize_scraping
+    @url_manager = UrlManager.new(options[:resume])
+    @target_url = @url_manager.retrieve_target_url
+    @current_page = DocumentFetcher.fetch_document_from_url(@target_url)
+    @shops_count = 0
+  end
+
+  def reached_limit?
+    @shops_count >= options[:limit]
+  end
+
+  def process_current_target_url
+    shop_links = filter_shop_links
+    process_shop_links(shop_links)
+  end
+
+  def filter_shop_links
+    shop_links = ShopInfoExtractor.extract_shop_links(@current_page)
+    return shop_links unless options[:resume] && File.exist?(UrlManager::LAST_LINK_FILE)
+
+    retrieve_remaining_shop_links(shop_links)
+  end
+
+  def retrieve_remaining_shop_links(shop_links)
+    last_link = UrlManager.retrieve_last_shop_url
+    start_index = shop_links.index(last_link)
+
+    if start_index
+      shop_links[start_index + 1..]
+    else
+      puts 'Continuing from the beginning of the next page.'
+      shop_links
+    end
+  end
+
+  def process_shop_links(shop_links)
+    shop_links.each do |link|
+      break if reached_limit?
+
+      process_shop_link(link)
+      @shops_count += 1
+    end
+  end
+
+  def process_shop_link(link)
+    sleep WAIT_SECONDS
+    shop_url = UrlManager.build_url(link)
+    execute(shop_url)
+    UrlManager.save_last_link(link)
+  end
+
+  def update_target_url
+    next_link = next_page_link
+    return unless next_link
+
+    @url_manager.save_last_page(@target_url)
+    @target_url = UrlManager.build_url(next_link)
+    @current_page = DocumentFetcher.fetch_document_from_url(@target_url)
+  end
+
+  def next_page_link
+    next_link_node = @current_page.at_xpath('//div[@class="pages"]/a[@class="next"]/@onclick')
+    return unless next_link_node
+
+    match = next_link_node.value.match(/window.location.href='(.*?)'/)
+    match[1] if match
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,3 @@
-Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test


### PR DESCRIPTION
## やったこと
- selenium-webdriverのアップデート
- ラーメン店スクレイピングタスクの実装
  - ScrapingのThorタスクを実装
    - executeタスク: 指定urlから店舗情報をDBとCSVに格納
    - scrape_ramen_shopsタスク: オプションに応じて繰り返しexecuteタスクを実行
  - Scrapingで使用するサービスクラスを実装
    - UrlManager: URLの管理、取得、および保存に関するタスクを担当。
    - DocumentFetcher: URLからのHTMLドキュメントの取得を担当。
    - ShopInfoExtractor: HTMLドキュメントから店舗情報を抽出するタスクを担当。
    - ShopInfoInserter: 抽出された店舗情報のデータベースへの挿入やCSVへの保存を担当。

## 動作確認
以下用件通りに正常に動作することを確認した
  - 30秒ごとに1店舗ずつ店舗情報を取得すること
  - 最後に取得したページと店舗からスクレイピングを再開できること
  - タスク実行時に取得する店舗数を指定できること
  - 指定店舗単独でも店舗情報を取得できること
  - 取得した情報はDBに格納後、seed用にcsvにも情報を格納すること
### RuboCop
指摘なし
### RSpec
全てパス
