### PR TITLE
ゲストユーザーでもお気に入りボタンと接続ボタンを表示させる

### DIFF
--- a/app/controllers/ramen_shops_controller.rb
+++ b/app/controllers/ramen_shops_controller.rb
@@ -1,7 +1,7 @@
 class RamenShopsController < ApplicationController
-  before_action :set_ramen_shop, only: %i[show edit update]
-  before_action :logged_in_user, only: %i[new edit create update]
+  before_action :logged_in_user, only: %i[new edit create update prepare_favorite]
   before_action :admin_user,     only: %i[new edit create update]
+  before_action :set_ramen_shop, only: %i[show edit update prepare_favorite]
 
   def index
     @search = RamenShop.ransack(params[:q])
@@ -55,6 +55,10 @@ class RamenShopsController < ApplicationController
 
     @ramen_shops = RamenShop.near([current_lat, current_lng], TARGET_RADIUS)
     render json: @ramen_shops
+  end
+
+  def prepare_favorite
+    redirect_to ramen_shop_path(@ramen_shop)
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  before_action :disable_connect_button, only: %i[new]
+
   def new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :logged_in_user, only: %i[index edit update destroy favorite_shops update_test_mode]
   before_action :correct_user, only: %i[edit update favorite_shops]
   before_action :admin_user, only: %i[index destroy update_test_mode]
+  before_action :disable_connect_button, only: %i[new edit]
 
   def index
     @users = User.where(activated: true).page(params[:page])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
       reverse: true,
       icon: [
         { href: image_url('favicon.ico') },
-        { href: image_url('favicon.ico'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },
+        { href: image_url('favicon.ico'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' }
       ],
       charset: 'utf-8',
       description: '行列に並ぶ「接続」から、ラーメンが提供される「着丼」までの時間を計測して共有しよう',

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="bg-light text-center text-lg-start">
-  <% if logged_in? && show_connect_button? %>
+  <% if show_connect_button? %>
     <div class="p-1 fixed-bottom">
       <div class="d-grid col-sm-6 mx-auto">
         <% if remember_record? %>

--- a/app/views/ramen_shops/_favorite_form.html.erb
+++ b/app/views/ramen_shops/_favorite_form.html.erb
@@ -1,7 +1,13 @@
 <div id="favorite_form">
-  <% if current_user.favorites?(@ramen_shop) %>
-    <%= render 'remove_favorite' %>
+  <% if logged_in? %>
+    <% if current_user.favorites?(@ramen_shop) %>
+      <%= render 'remove_favorite' %>
+    <% else %>
+      <%= render 'add_favorite' %>
+    <% end %>
   <% else %>
-    <%= render 'add_favorite' %>
+    <%= link_to prepare_favorite_ramen_shop_path(@ramen_shop), class: 'btn btn-sm btn-outline-dark' do %>
+      <i class="fa-solid fa-star"></i> お気に入り
+    <% end %>
   <% end %>
 </div>

--- a/app/views/ramen_shops/show.html.erb
+++ b/app/views/ramen_shops/show.html.erb
@@ -8,7 +8,7 @@
         レコード数
       <% end %>
     </div>
-    <%= render 'favorite_form' if logged_in? %>
+    <%= render 'favorite_form' %>
   </section>
   <section class="content">
     <h2 class="border-bottom">ちゃくどんレコード</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   resources :ramen_shops, only: [:index, :show, :new, :create, :edit, :update] do
+    member do
+      get :prepare_favorite
+    end
     resources :records, only: [:show, :new, :create, :edit, :update], shallow: true do
       member do
         get 'measure'


### PR DESCRIPTION
## やったこと
ゲストユーザーで非表示にしていたボタンを表示
- ラーメン店ページでのお気に入りボタンを表示
  - ログインしていない場合に反応するprepare_favoriteアクションを実装
- 現在地から接続ボタンを表示
  - ユーザー新規登録と更新ページでは非表示に設定

## 動作確認
### RuboCop
指摘なし
### RSpec
全てパス