### PR TITLE
Line status入力フォームの改善

### DIFF
--- a/app/assets/stylesheets/component/_form.scss
+++ b/app/assets/stylesheets/component/_form.scss
@@ -14,4 +14,16 @@ label {
     right: -34px;
     top: 0;
   }
+  &.optional:after {
+    background-color: g.$brand-light-gray-color;
+    opacity: .7;
+    border-radius: 8px;
+    color: #fff;
+    content: "任意";
+    font-size: 10px;
+    padding: 0.2rem 0.4rem;
+    position: absolute;
+    right: -40px;
+    top: 0;
+  }
 }

--- a/app/assets/stylesheets/views/line_statuses/_form.scss
+++ b/app/assets/stylesheets/views/line_statuses/_form.scss
@@ -1,0 +1,12 @@
+.line-number-label {
+  display: flex;
+  gap: 50px;
+  a {
+    font-size: 16px;
+  }
+}
+
+.popover {
+  --bs-popover-bg: #f0f0f0;
+  max-width: 280px;
+}

--- a/app/assets/stylesheets/views/line_statuses/_form.scss
+++ b/app/assets/stylesheets/views/line_statuses/_form.scss
@@ -8,5 +8,11 @@
 
 .popover {
   --bs-popover-bg: #f0f0f0;
-  max-width: 280px;
+  max-width: 290px;
+  .popover-body {
+    width: fit-content;
+    span {
+      display: inline-block;
+    }
+  }
 }

--- a/app/assets/stylesheets/views/line_statuses/_index.scss
+++ b/app/assets/stylesheets/views/line_statuses/_index.scss
@@ -1,1 +1,2 @@
 @use "line_status";
+@use "form";

--- a/app/helpers/line_statuses_helper.rb
+++ b/app/helpers/line_statuses_helper.rb
@@ -11,7 +11,7 @@ module LineStatusesHelper
   end
 
   def line_status_content(line_status)
-    if line_status.line_type == 'seated'
+    if line_status.line_type == 'seated' || line_status.line_number.nil?
       line_status.line_type_i18n.to_s
     else
       "#{line_status.line_type_i18n} - #{line_status.line_number}人"

--- a/app/javascript/controllers/popover_controller.js
+++ b/app/javascript/controllers/popover_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus";
+import { Popover } from "bootstrap";
+
+// Connects to data-controller="popover"
+export default class extends Controller {
+  connect() {
+    new Popover(this.element);
+  }
+}

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -6,7 +6,7 @@ class LineStatus < ApplicationRecord
 
   enum line_type: { inside_the_store: 1, outside_the_store: 2, seated: 3 }
 
-  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
   validates :comment, length: { maximum: 140, too_long: '最大%<count>s文字まで使えます' }
   validates :image, content_type: { in: %i[png jpg jpeg],
                                     message: 'のフォーマットが不正です' },

--- a/app/views/line_statuses/_form.html.erb
+++ b/app/views/line_statuses/_form.html.erb
@@ -7,11 +7,11 @@
     </div>
   <% end %>
   <div class="line-number-box" data-line-status-target="lineNumberField">
-    <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" } %>
+    <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" }, label_class: 'optional' %>
   </div>
 </div>
-<%= f.text_area :comment, label: { text: "ひとこと" }, placeholder: '行列の様子や心境をどうぞ！' %>
+<%= f.text_area :comment, label: { text: "ひとこと" }, placeholder: '行列の様子や心境をどうぞ！', label_class: 'optional' %>
 <div class="image" data-controller="image-uploader">
-  <%= f.file_field :image, accept: "image/jpeg,image/jpg,image/png", data: { action: "change->image-uploader#displayAfterCheck", image_uploader_target: "image" } %>
+  <%= f.file_field :image, accept: "image/jpeg,image/jpg,image/png", data: { action: "change->image-uploader#displayAfterCheck", image_uploader_target: "image" }, label_class: 'optional' %>
   <%= image_tag '', data: { image_uploader_target: "imagePrev" }, class: 'image-prev', style: 'display:none' %>
 </div>

--- a/app/views/line_statuses/_form.html.erb
+++ b/app/views/line_statuses/_form.html.erb
@@ -7,7 +7,13 @@
     </div>
   <% end %>
   <div class="line-number-box" data-line-status-target="lineNumberField">
-    <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" }, label_class: 'optional' %>
+    <div class="line-number-label">
+      <%= f.label :line_number, class: 'form-label optional' %>
+      <a tabindex="0" role="button" data-bs-toggle="popover" data-controller="popover" data-bs-trigger="focus" data-bs-content="自分の前に並んでいる人数を入力します。（前に人がいない場合は0）">
+        <i class="fa-regular fa-circle-question"></i>
+      </a>
+    </div>
+    <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', data: { line_status_target: "lineNumberInput" }, hide_label: true %>
   </div>
 </div>
 <%= f.text_area :comment, label: { text: "ひとこと" }, placeholder: '行列の様子や心境をどうぞ！', label_class: 'optional' %>

--- a/app/views/line_statuses/_form.html.erb
+++ b/app/views/line_statuses/_form.html.erb
@@ -9,7 +9,8 @@
   <div class="line-number-box" data-line-status-target="lineNumberField">
     <div class="line-number-label">
       <%= f.label :line_number, class: 'form-label optional' %>
-      <a tabindex="0" role="button" data-bs-toggle="popover" data-controller="popover" data-bs-trigger="focus" data-bs-content="自分の前に並んでいる人数を入力します。（前に人がいない場合は0）">
+      <a data-controller="popover" tabindex="0" role="button" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-html="true"
+        data-bs-content="<span>自分の前に並んでいる人数を入力します。</span><span>※前に人がいない場合は0</span>">
         <i class="fa-regular fa-circle-question"></i>
       </a>
     </div>

--- a/app/views/records/result.html.erb
+++ b/app/views/records/result.html.erb
@@ -10,9 +10,9 @@
     </div>
   </div>
   <%= bootstrap_form_with model: @record, class: 'record-result-form' do |f| %>
-    <%= f.text_area :comment, label: { text: "ひとこと" }, placeholder: 'ちゃくどん後の心境をどうぞ！' %>
+    <%= f.text_area :comment, label: { text: "ひとこと" }, placeholder: 'ちゃくどん後の心境をどうぞ！', label_class: 'optional' %>
     <div class="image" data-controller="image-uploader">
-      <%= f.file_field :image, accept: "image/jpeg,image/jpg,image/png", data: { action: "change->image-uploader#displayAfterCheck", image_uploader_target: "image" } %>
+      <%= f.file_field :image, accept: "image/jpeg,image/jpg,image/png", data: { action: "change->image-uploader#displayAfterCheck", image_uploader_target: "image" }, label_class: 'optional' %>
       <%= image_tag '', data: { image_uploader_target: "imagePrev" }, class: 'image-prev', style: 'display:none' %>
     </div>
     <div class="d-grid mb-3">

--- a/spec/models/line_status_spec.rb
+++ b/spec/models/line_status_spec.rb
@@ -19,10 +19,9 @@ RSpec.describe LineStatus do
     expect { line_status.line_type = 'invalid' }.to raise_error(ArgumentError, "'invalid' is not a valid line_type")
   end
 
-  it 'is invalid with blank line_number' do
+  it 'is valid with blank line_number' do
     line_status.line_number = ''
-    line_status.valid?
-    expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
+    expect(line_status).to be_valid
   end
 
   it 'is invalid with string line_number' do


### PR DESCRIPTION
## やったこと
- 待ち人数を毎度正確に入力することは困難なため、任意入力に変更
- 待ち人数の定義をpopoverで表示
- フォームの任意入力項目は任意ラベルを表示(resultページ含む）

## 動作確認
任意ラベルとpopoverが表示されることを確認
![image](https://github.com/moriw0/tyakudon/assets/87155363/23ec7897-3668-44cc-8600-d5ee3872c776)

### RuboCop
指摘なし
### RSpec
全てパス