### PR TITLE
静的エラーページの文言変更

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>ご指定になったページは存在しません | ちゃくどん</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -51,6 +51,14 @@
     color: #666;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
+  .normal-link {
+    color: #5f5b5b;
+    text-decoration: none;
+  }
+  .normal-link:hover {
+    color: #5f5b5b;
+    opacity: 0.8;
+  }
   </style>
 </head>
 
@@ -58,10 +66,10 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>ご指定になったページは存在しません</h1>
+      <p>ご指定のページは変更か削除された可能性があります。</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p><a class="normal-link" href="/">トップページへ戻る</a></p>
   </div>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The change you wanted was rejected (422)</title>
+  <title>ページが表示できません | ちゃくどん</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -58,10 +58,10 @@
   <!-- This file lives in public/422.html -->
   <div class="dialog">
     <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+      <h1>ページが表示できません</h1>
+      <p>申し訳ありません。内部エラーによりページが表示できませんでした。</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p><a class="normal-link" href="/">トップページへ戻る</a></p>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>ページが表示できません | ちゃくどん</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -51,6 +51,14 @@
     color: #666;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
+  .normal-link {
+    color: #5f5b5b;
+    text-decoration: none;
+  }
+  .normal-link:hover {
+    color: #5f5b5b;
+    opacity: 0.8;
+  }
   </style>
 </head>
 
@@ -58,9 +66,10 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>ページが表示できません</h1>
+      <p>申し訳ありません。内部エラーによりページが表示できませんでした。</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p><a class="normal-link" href="/">トップページへ戻る</a></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## やったこと
静的エラーページの文言変更
- 404ページ
- 422ページ
- 500ページ

## 動作確認
表示されることを確認
<img width="377" alt="image" src="https://github.com/moriw0/tyakudon/assets/87155363/49ddd8f1-4a73-4f01-8b67-a27c6d8467c2">

### RuboCop
指摘なし
### RSpec
全てパス