### PR TITLE
Record・LineStatusコントローラに認可を追加

### DIFF
--- a/app/controllers/line_statuses_controller.rb
+++ b/app/controllers/line_statuses_controller.rb
@@ -2,6 +2,7 @@ class LineStatusesController < ApplicationController
   before_action :logged_in_user, except: %i[show]
   before_action :set_record, only: %i[new create]
   before_action :set_line_status, only: %i[show edit update]
+  before_action :correct_user, except: %i[show]
 
   def show
   end
@@ -42,6 +43,15 @@ class LineStatusesController < ApplicationController
 
   def set_line_status
     @line_status = LineStatus.find(params[:id])
+  end
+
+  def correct_user
+    user = @record&.user || @line_status.record.user
+    record_user = User.find(user.id)
+    return if current_user?(record_user)
+
+    flash.alert = '不正なアクセスです'
+    redirect_to root_path, status: :see_other
   end
 
   def line_status_params

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -3,6 +3,7 @@ class RecordsController < ApplicationController
 
   before_action :logged_in_user, except: %i[show]
   before_action :set_record, except: %i[new create]
+  before_action :correct_user, except: %i[show new create]
   before_action :set_ramen_shop, except: %i[new create retire]
   before_action :check_auto_retired, only: %i[measure calculate retire]
   before_action :disable_connect_button, only: %i[measure result]
@@ -75,6 +76,14 @@ class RecordsController < ApplicationController
 
   def set_record
     @record = Record.find(params[:id])
+  end
+
+  def correct_user
+    user = User.find(@record.user.id)
+    return if current_user?(user)
+
+    flash.alert = '不正なアクセスです'
+    redirect_to root_path, status: :see_other
   end
 
   def set_ramen_shop

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -26,5 +26,11 @@ FactoryBot.define do
       sequence(:ended_at) { |n| (n + 10).minutes.from_now }
       sequence(:created_at) { |n| n.minute.from_now }
     end
+
+    factory :record_only_has_started_at do
+      ended_at { nil }
+      wait_time { nil }
+      comment { nil }
+    end
   end
 end

--- a/spec/requests/line_statuses_spec.rb
+++ b/spec/requests/line_statuses_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe 'LineStatuses' do
       do_request
       expect(response.body).to include '<h5 class="modal-title">行列の様子を報告</h5>'
     end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
   describe 'GET /line_statuses/:id/edit #edit' do
@@ -40,6 +58,24 @@ RSpec.describe 'LineStatuses' do
       log_in_as(user)
       do_request
       expect(response.body).to include '<h5 class="modal-title">編集</h5>'
+    end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
+      end
     end
   end
 
@@ -60,6 +96,24 @@ RSpec.describe 'LineStatuses' do
         }.to change(LineStatus, :count).by(1)
       end
     end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
   describe 'PATCH /line_statuses/:id #update' do
@@ -73,6 +127,24 @@ RSpec.describe 'LineStatuses' do
       line_status.update(line_number: 5)
       do_request
       expect(line_status.reload.line_number).to eq 4
+    end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
+      end
     end
   end
 end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe 'Records' do
   end
 
   describe 'GET /records/:id/measure #measure' do
+    let(:record) { create(:record_only_has_started_at, ramen_shop: ramen_shop, user: user) }
     let(:do_request) { get measure_record_path(record) }
 
     it_behaves_like 'when not logged in'
@@ -88,6 +89,7 @@ RSpec.describe 'Records' do
 
       context 'when the record.ended_at? is true' do
         it 'redirects to root_path' do
+          record.update!(ended_at: Time.zone.now)
           do_request
           expect(response).to redirect_to root_path
         end
@@ -95,15 +97,34 @@ RSpec.describe 'Records' do
 
       context 'with auto_retired? is true' do
         it 'redirects to root_path' do
-          record.update(auto_retired: true)
+          record.update!(auto_retired: true)
           do_request
           expect(response).to redirect_to root_path
         end
       end
     end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
   describe 'GET /records/:id/calculate #calculate' do
+    let(:record) { create(:record_only_has_started_at, ramen_shop: ramen_shop, user: user) }
     let(:do_request) { patch calculate_record_path(record), params: calculated_record_params }
     let(:calculated_record_params) do
       started_at = record.started_at
@@ -120,29 +141,47 @@ RSpec.describe 'Records' do
       end
 
       it 'updates wait_time' do
-        record.update(started_at: 5.minutes.ago, ended_at: nil, wait_time: nil)
+        record.update!(started_at: 5.minutes.ago, ended_at: nil, wait_time: nil)
         do_request
         expect(record.reload.wait_time).to_not be_nil
       end
 
       it 'redirects to root_path if ended' do
-        record.update(ended_at: Time.zone.now)
+        record.update!(ended_at: Time.zone.now)
         do_request
         expect(response).to redirect_to root_path
       end
 
       context 'with auto_retired? is true' do
         it 'redirects to root_path' do
-          record.update(auto_retired: true)
+          record.update!(auto_retired: true)
           do_request
           expect(response).to redirect_to root_path
         end
 
         it 'has a flash notices record has retired' do
-          record.update(auto_retired: true)
+          record.update!(auto_retired: true)
           do_request
           expect(flash[:notice]).to eq '記録は無効になっています'
         end
+      end
+    end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
       end
     end
   end
@@ -162,6 +201,24 @@ RSpec.describe 'Records' do
         expect(response.body).to include 'ひとこと'
       end
     end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
   describe 'PATCH /records/:id #update' do
@@ -176,7 +233,7 @@ RSpec.describe 'Records' do
       end
 
       it 'updates comment' do
-        record.update(comment: nil)
+        record.update!(comment: nil)
         do_request
         expect(record.reload.comment).to include 'ちゃくどん'
       end
@@ -190,6 +247,24 @@ RSpec.describe 'Records' do
         invalid_record_params = { record: { comment: 'a' * 141 } }
         patch record_path(record), params: invalid_record_params
         expect(response.body).to include 'は140文字以内で入力してください'
+      end
+    end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
       end
     end
   end
@@ -228,6 +303,24 @@ RSpec.describe 'Records' do
           do_request
           expect(response).to redirect_to root_path
         end
+      end
+    end
+
+    context 'when logged in as other_user' do
+      let(:other_user) { create(:other_user) }
+
+      before do
+        log_in_as(other_user)
+      end
+
+      it 'has a flash notices incorrect user' do
+        do_request
+        expect(flash[:alert]).to eq '不正なアクセスです'
+      end
+
+      it 'redirects to root_path' do
+        do_request
+        expect(response).to redirect_to root_path
       end
     end
   end


### PR DESCRIPTION
## やったこと
他ユーザーからレコードを操作できなくするよう、RecordとLineStatusコントローラに認可を追加
- current_userとレコード保持userの一致確認をするcorrect_userメソッドの追加
- 認可を検証するSpecを追加

## 動作確認
動作検証Specにて正常に動作することを確認

### RuboCop
指摘なし
### RSpec
全てパス