### PR TITLE
AWSデプロイセッティング

### DIFF
--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -12,4 +12,5 @@ class LineStatus < ApplicationRecord
                                     message: 'のフォーマットが不正です' },
                     size: { less_than_or_equal_to: 5.megabytes,
                             message: 'は5MB以下である必要があります' }
+  default_scope { order(:id) }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Tyakudon
         helper_specs: false,
         routing_specs: false
     end
-    config.active_storage.variant_processor = :mini_magick
+    config.active_storage.variant_processor = :vips
 
     # config.active_job.queue_adapter = :delayed_job
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -83,4 +83,8 @@ production:
   <<: *default
   adapter: postgresql
   encoding: unicode
-  url: <%= ENV['DATABASE_URL'] %>
+  database: <%= ENV['DB_DATABASE'] %>
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  host: <%= ENV['DB_HOST'] %>
+  port: <%= ENV['DB_PORT'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  host = 'tyakudon.onrender.com'
+  host = 'tyakudon.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
     :port           => 587,

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,3 +7,5 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 workers ENV.fetch("WEB_CONCURRENCY") { 4 }
 preload_app!
 plugin :tmp_restart
+app_root = File.expand_path("../..", __FILE__)
+bind "unix:#{app_root}/tmp/sockets/puma.sock"


### PR DESCRIPTION
## やったこと
- 本番で使用するDBの環境変数情報を細かく入力できるよう改善
- nginx連携のため、pumaとforce_sslの設定を変更
- mailerの設定として変更したドメイン名を適用
- その他
  - メモリ省力化のため画像処理にvipsを使用するように変更
  - line_statusesで取得するデータ順をid昇順に強制する fixes #84 

## 動作確認
AWS上で動作することを確認
[ちゃくどん](https://tyakudon.com/)

### RuboCop
指摘なし