### PR TITLE
CI改善とシステムスペックの保留解除

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -26,6 +26,11 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Install libvips
+        run: |
+          sudo apt update -y
+          sudo apt install -y libvips
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -33,23 +38,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.2
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
           node-version: 16.8
-
-      - name: Cache bundle
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: bundle-v1-${{ hashFiles('Gemfile.lock') }}
-
-      - name: Run bundle install
-        run: |
-          bundle config --local path vendor/bundle
-          bundle config --local without production
-          bundle install
 
       - name: Run precompile
         run: RAILS_ENV=test bundle exec rails assets:precompile
@@ -76,6 +70,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.2.2
           bundler-cache: true
 
       - name: Run rubocop

--- a/spec/support/geolocation_helper.rb
+++ b/spec/support/geolocation_helper.rb
@@ -1,0 +1,25 @@
+module GeolocationHelper
+  module System
+    # rubocop:disable Metrics/MethodLength
+    def mock_geolocation(lat, lon)
+      script = <<-JS
+        navigator.geolocation.getCurrentPosition = (success) => {
+          var position = {
+            coords: {
+              latitude: #{lat},
+              longitude: #{lon}
+            }
+          };
+          success(position);
+        };
+      JS
+
+      page.execute_script(script)
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end
+
+RSpec.configure do |config|
+  config.include GeolocationHelper::System, type: :system
+end

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -6,18 +6,15 @@ RSpec.describe 'Records', js: true do
 
   before do
     log_in_as(user)
+    mock_geolocation(50.455755, 30.511565)
   end
 
   scenario 'user creates a record of the nearby ramen shop' do
-    pending 'headlessで動作できないため、pending中'
-
     click_link '現在地から接続'
 
     # searchページ
     expect(page).to_not have_link '現在地から接続'
-    expect(page).to have_css '.loading-spinner'
-    expect(page).to have_css '#map', visible: :visible, wait: 15
-    expect(page).to_not have_css '.loading-spinner'
+    expect(page).to have_css '#map', visible: :visible
 
     # 接続するラーメン店を選択して最初の待ち行列情報を入力
     click_link ramen_shop.name, href: new_ramen_shop_record_path(ramen_shop)

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -47,10 +47,9 @@ RSpec.describe 'Records', js: true do
     find('label[for="line_status_line_type_inside_the_store"]').click
     fill_in '待ち行列数', with: 1
     fill_in 'ひとこと', with: 'もう少し'
-    click_button '報告する'
-    ## 暫定対策: responseを待ってからmodalを強制的に閉じる
+    ## 暫定対策: 一呼吸おいてからpost投稿
     sleep(1)
-    find('button[data-bs-dismiss="modal"]').click
+    click_button '報告する'
 
     # measureページに追加登録情報が反映されている
     expect(page).to have_content '行列の様子を報告しました'


### PR DESCRIPTION
## やったこと
- CIの改善
  - 重複していたキャッシュとbundle installをSetupRubyへ統合
  - libvipsインストールを追加
- recordsのシステムスペックの改善
  - 現在地を取得するスクリプトをモック化
  - モーダルが閉じない暫定対策をclick_buttonする前にsleepへ変更

## 動作確認
変更したスペックが環境開発、およびGitHubActionsで動作することを確認