### PR TITLE
Docker上でheadless_chromeを使用できるよう改善

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.2.2
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs libvips-dev
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs libvips-dev chromium chromium-driver
 
 ENV APP_PATH /tyakudon
 

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,6 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", '>= 4.15.0'
   gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ GEM
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    selenium-webdriver (4.11.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -435,7 +435,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     webrick (1.8.1)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -485,7 +485,7 @@ DEPENDENCIES
   rubocop-rspec
   ruby-openai
   seed-fu
-  selenium-webdriver
+  selenium-webdriver (>= 4.15.0)
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,9 +1,17 @@
+Capybara.register_driver :selenium_chrome_custom do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
 
   config.before(:each, js: true, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium_chrome_custom
   end
 end


### PR DESCRIPTION
## やったこと
- 最新バージョン以上のselenium-webdriverを指定
- Dockerイメージにchromium chromium-driverを追加
- クラッシュを防ぐオプションを指定してドライバ生成

## 動作確認
Docker上、GitHubActions上でRSpecが実行できることを確認