### PR TITLE
ちゃくどんレコードに対するいいね機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ bundle-update:
 db-migrate:
 	docker-compose run --rm app bundle exec rails db:migrate RAILS_ENV=development
 
+db-seed:
+	docker-compose run --rm app bundle exec rails db:seed RAILS_ENV=development
+
 precompile:
 	docker-compose run --rm app bundle exec rails assets:precompile RAILS_ENV=development
 

--- a/app/assets/stylesheets/component/_button.scss
+++ b/app/assets/stylesheets/component/_button.scss
@@ -30,33 +30,53 @@
   border-radius: 20px;
 }
 
-.like-button {
+%base-button {
   align-items: center;
-  background-color: transparent;
   border: 1px solid #000;
   border-radius: 5px;
   cursor: pointer;
   display: flex;
-  margin: 0 5px;
-  outline: none;
+  font-size: 12px;
   padding: 5px 10px;
   text-decoration: none;
-  &.clicked {
-    background-color: #000;
+  outline: none;
+}
+
+@keyframes like-beat {
+  0%, 100% {
+    transform: scale(1) rotate(0deg);
   }
-  .like-icon {
-    color: #000;
-    font-size: 14px;
-    &.clicked {
-      color: #ffffff;
-    }
+  50% {
+    transform: scale(1.5) rotate(-10deg);
+  }
+}
+
+.like-button {
+  @extend %base-button;
+  background-color: transparent;
+  &.clicked {
+    background-color: g.$brand-yellow-color;
+    border-color: g.$brand-yellow-color;
+  }
+  .like-icon, .like-count {
+    color: black;
   }
   .like-count {
-    color: #000000;
-    font-size: 14px;
     margin-left: 8px;
-    &.clicked {
-      color: #fff
-    }
+  }
+  .like-beat {
+    animation: like-beat 0.3s ease-in-out;
+  }
+}
+
+.share-button {
+  @extend %base-button;
+  background-color: black;
+  color: white;
+  &:hover {
+    color: white;
+  }
+  .share-text {
+    margin-left: 8px;
   }
 }

--- a/app/assets/stylesheets/component/_button.scss
+++ b/app/assets/stylesheets/component/_button.scss
@@ -29,3 +29,34 @@
   padding: 0.3rem 1rem;
   border-radius: 20px;
 }
+
+.like-button {
+  align-items: center;
+  background-color: transparent;
+  border: 1px solid #000;
+  border-radius: 5px;
+  cursor: pointer;
+  display: flex;
+  margin: 0 5px;
+  outline: none;
+  padding: 5px 10px;
+  text-decoration: none;
+  &.clicked {
+    background-color: #000;
+  }
+  .like-icon {
+    color: #000;
+    font-size: 14px;
+    &.clicked {
+      color: #ffffff;
+    }
+  }
+  .like-count {
+    color: #000000;
+    font-size: 14px;
+    margin-left: 8px;
+    &.clicked {
+      color: #fff
+    }
+  }
+}

--- a/app/assets/stylesheets/views/records/_show.scss
+++ b/app/assets/stylesheets/views/records/_show.scss
@@ -15,19 +15,11 @@
         margin-left: 0.5rem;
       }
     }
-    .share-button {
-      display: inline-block;
-      font-size: 12px;
-      text-decoration: none;
-      padding: 0.5rem;
-      background-color: black;
-      color: white;
-      border-radius: 5px;
-      &:hover {
-        background-color: white;
-        color: black;
-        border: 1px solid black;
-      }
+    .header-buttons {
+      align-items: center;
+      display: flex;
+      gap: 5px;
+      justify-content: end;
     }
   }
   .record-content {

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,7 @@
+class LikesController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,7 +1,18 @@
 class LikesController < ApplicationController
+  before_action :logged_in_user
+
   def create
+    @record = Record.find(params[:record_id])
+    current_user.add_like(@record)
   end
 
   def destroy
+    @record = Like.find(params[:id]).record
+    current_user.remove_like(@record)
+  end
+
+  def prepare
+    @record = Record.find(params[:id])
+    redirect_to record_path(@record)
   end
 end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :record
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -5,6 +5,7 @@ class Record < ApplicationRecord
   has_one_attached :image do |attachable|
     attachable.variant :display, resize_to_limit: [750, 750]
   end
+  has_many :likes, dependent: :destroy
   has_many :cheer_messages, dependent: :destroy
   accepts_nested_attributes_for :line_statuses
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class User < ApplicationRecord
   attr_accessor :remember_token, :activation_token, :reset_token
 
@@ -5,6 +6,7 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :restrict_with_exception
   has_many :favorite_shops, through: :favorites, source: :ramen_shop
   has_many :likes, dependent: :restrict_with_exception
+  has_many :like_records, through: :likes, source: :record
   has_one_attached :avatar
 
   before_save :downcase_email
@@ -108,6 +110,18 @@ class User < ApplicationRecord
     favorite_shops.delete(shop) if favorites?(shop)
   end
 
+  def likes?(record)
+    like_records.include?(record)
+  end
+
+  def add_like(record)
+    like_records << record unless likes?(record)
+  end
+
+  def remove_like(record)
+    like_records.delete(record) if likes?(record)
+  end
+
   private
 
   def downcase_email
@@ -123,3 +137,4 @@ class User < ApplicationRecord
     errors.add(:password, :blank) if password_digest.blank?
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :records, dependent: :restrict_with_exception
   has_many :favorites, dependent: :restrict_with_exception
   has_many :favorite_shops, through: :favorites, source: :ramen_shop
+  has_many :likes, dependent: :restrict_with_exception
   has_one_attached :avatar
 
   before_save :downcase_email

--- a/app/views/likes/_add_like.html.erb
+++ b/app/views/likes/_add_like.html.erb
@@ -1,6 +1,6 @@
-<%= form_with(model: current_user.likes.build) do |f| %>
+<%= form_with model: current_user.likes.build do |f| %>
   <div><%= hidden_field_tag :record_id, @record.id %></div>
-  <%= f.button :type => "submit", class: 'like-button' do %>
+  <%= f.button :type => "submit", class: 'like-button', data: { action: "click->icon#beat" } do %>
     <i class="fa-regular fa-thumbs-up like-icon"></i>
     <span class="like-count"><%= @record.likes.count %></span>
   <% end %>

--- a/app/views/likes/_add_like.html.erb
+++ b/app/views/likes/_add_like.html.erb
@@ -1,0 +1,7 @@
+<%= form_with(model: current_user.likes.build) do |f| %>
+  <div><%= hidden_field_tag :record_id, @record.id %></div>
+  <%= f.button :type => "submit", class: 'like-button' do %>
+    <i class="fa-regular fa-thumbs-up like-icon"></i>
+    <span class="like-count"><%= @record.likes.count %></span>
+  <% end %>
+<% end %>

--- a/app/views/likes/_like_form.html.erb
+++ b/app/views/likes/_like_form.html.erb
@@ -1,0 +1,14 @@
+<div id="like_form">
+  <% if logged_in? %>
+    <% if current_user.likes?(@record) %>
+      <%= render 'likes/remove_like' %>
+    <% else %>
+      <%= render 'likes/add_like' %>
+    <% end %>
+  <% else %>
+    <%= link_to prepare_like_path(@record), class: 'like-button' do %>
+      <i class="fa-regular fa-thumbs-up like-icon"></i>
+      <span class="like-count"><%= @record.likes.count %></span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/likes/_remove_like.html.erb
+++ b/app/views/likes/_remove_like.html.erb
@@ -1,6 +1,7 @@
-<%= form_with(model: current_user.likes.find_by(record: @record), html: { method: :delete }) do |f| %>
+<% move_icon ||= false %>
+<%= form_with model: current_user.likes.find_by(record: @record), html: { method: :delete } do |f| %>
   <%= f.button :type => "submit", class: 'like-button clicked' do %>
-    <i class="fa-solid fa-thumbs-up like-icon clicked"></i>
-    <span class="like-count clicked"><%= @record.likes.count %></span>
+    <i class="fa-solid fa-thumbs-up like-icon <%= 'like-beat' if move_icon %>"></i>
+    <span class="like-count"><%= @record.likes.count %></span>
   <% end %>
 <% end %>

--- a/app/views/likes/_remove_like.html.erb
+++ b/app/views/likes/_remove_like.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(model: current_user.likes.find_by(record: @record), html: { method: :delete }) do |f| %>
+  <%= f.button :type => "submit", class: 'like-button clicked' do %>
+    <i class="fa-solid fa-thumbs-up like-icon clicked"></i>
+    <span class="like-count clicked"><%= @record.likes.count %></span>
+  <% end %>
+<% end %>

--- a/app/views/likes/create.html.erb
+++ b/app/views/likes/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Likes#create</h1>
-<p>Find me in app/views/likes/create.html.erb</p>

--- a/app/views/likes/create.html.erb
+++ b/app/views/likes/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Likes#create</h1>
+<p>Find me in app/views/likes/create.html.erb</p>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "like_form" do %>
-  <%= render partial: "remove_like" %>
+  <%= render partial: "remove_like", locals: { move_icon: true } %>
 <% end %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "like_form" do %>
+  <%= render partial: "remove_like" %>
+<% end %>

--- a/app/views/likes/destroy.html.erb
+++ b/app/views/likes/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Likes#destroy</h1>
-<p>Find me in app/views/likes/destroy.html.erb</p>

--- a/app/views/likes/destroy.html.erb
+++ b/app/views/likes/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Likes#destroy</h1>
+<p>Find me in app/views/likes/destroy.html.erb</p>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "like_form" do %>
+  <%= render partial: "add_like" %>
+<% end %>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -1,6 +1,7 @@
 <div id="records-show">
   <div class="header">
     <h1 class="record-header">ちゃくどんレコード <span class="record-number">No. <%= @record.id %></span></h1>
+    <%= render 'likes/like_form' %>
     <%= link_to @tweet_url, onclick: "window.open(this.href, '_blank'); return false;", class: 'share-button' do%>
       <i class="fa-brands fa-twitter"></i> シェアする
     <% end %>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -1,10 +1,13 @@
 <div id="records-show">
   <div class="header">
-    <h1 class="record-header">ちゃくどんレコード <span class="record-number">No. <%= @record.id %></span></h1>
-    <%= render 'likes/like_form' %>
-    <%= link_to @tweet_url, onclick: "window.open(this.href, '_blank'); return false;", class: 'share-button' do%>
-      <i class="fa-brands fa-twitter"></i> シェアする
-    <% end %>
+    <h1 class="record-header">ちゃくどん<span class="record-number">No. <%= @record.id %></span></h1>
+    <div class="header-buttons">
+      <%= render 'likes/like_form' %>
+      <%= link_to @tweet_url, onclick: "window.open(this.href, '_blank'); return false;", class: 'share-button' do%>
+        <i class="fa-brands fa-twitter"></i>
+        <span class="share-text">シェア</span>
+      <% end %>
+    </div>
   </div>
   <div class="record-content">
     <div class="record-summary">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,6 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :favorites, only: [:create, :destroy]
+  resources :likes, only: [:create, :destroy]
   resources :cheer_messages, only: %i[create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,10 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :favorites, only: [:create, :destroy]
-  resources :likes, only: [:create, :destroy]
+  resources :likes, only: [:create, :destroy] do
+    member do
+      get :prepare
+    end
+  end
   resources :cheer_messages, only: %i[create]
 end

--- a/db/fixtures/development/sample_like.rb
+++ b/db/fixtures/development/sample_like.rb
@@ -1,0 +1,14 @@
+users = User.all
+records = Record.all
+
+likes = []
+
+users.each do |user|
+  liked_records = records.sample(100)
+
+  liked_records.each do |record|
+    likes << { user_id: user.id, record_id: record.id }
+  end
+end
+
+Like.seed(:user_id, :record_id, *likes)

--- a/db/migrate/20231210064653_create_likes.rb
+++ b/db/migrate/20231210064653_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :record, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, [:user_id, :record_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_04_033904) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_10_064653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -138,6 +138,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_033904) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_id"], name: "index_likes_on_record_id"
+    t.index ["user_id", "record_id"], name: "index_likes_on_user_id_and_record_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "line_statuses", force: :cascade do |t|
     t.bigint "record_id", null: false
     t.integer "line_number"
@@ -200,6 +210,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_033904) do
   add_foreign_key "cheer_messages", "records"
   add_foreign_key "favorites", "ramen_shops"
   add_foreign_key "favorites", "users"
+  add_foreign_key "likes", "records"
+  add_foreign_key "likes", "users"
   add_foreign_key "line_statuses", "records"
   add_foreign_key "records", "ramen_shops"
   add_foreign_key "records", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,3 +3,4 @@ SeedFu.seed(nil, /sample_user/) if ['development', 'test'].include? Rails.env
 SeedFu.seed(nil, /sample_favorite/) if ['development', 'test'].include? Rails.env
 SeedFu.seed(nil, /sample_record/) if ['development', 'test'].include? Rails.env
 SeedFu.seed(nil, /sample_line_status/) if ['development', 'test'].include? Rails.env
+SeedFu.seed(nil, /sample_like/) if ['development', 'test'].include? Rails.env

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user { nil }
+    record { nil }
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,24 +1,87 @@
 require 'rails_helper'
 
 RSpec.describe Like do
-  let(:user) { create(:user) }
-  let(:other_user) { create(:other_user) }
-  let(:record) { create(:record, user: other_user) }
+  describe 'Validations' do
+    context 'with user and record' do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:other_user) }
+      let!(:record) { create(:record, user: other_user) }
+      let!(:like) { user.likes.build(record: record) }
 
-  it 'is valid with user and record' do
-    like = user.likes.build(record: record)
-    expect(like).to be_valid
+      it 'is valid' do
+        expect(like).to be_valid
+      end
+    end
+
+    context 'without record' do
+      let!(:user) { create(:user) }
+      let!(:like) { user.likes.build(record: nil) }
+
+      it 'includes error message' do
+        like.valid?
+        expect(like.errors[:record]).to include 'を入力してください'
+      end
+    end
+
+    context 'without user' do
+      let!(:record) { create(:record) }
+      let!(:like) { described_class.new(record: record, user: nil) }
+
+      it 'includes error message' do
+        like.valid?
+        expect(like.errors[:user]).to include 'を入力してください'
+      end
+    end
   end
 
-  it 'is invalid without record' do
-    like = user.likes.build(record: nil)
-    like.valid?
-    expect(like.errors[:record]).to include 'を入力してください'
-  end
+  describe 'Model Methods' do
+    let!(:user) { create(:user) }
+    let!(:other_user) { create(:other_user) }
+    let!(:record) { create(:record, user: other_user) }
 
-  it 'is invalid without user' do
-    like = described_class.new(record: record, user: nil)
-    like.valid?
-    expect(like.errors[:user]).to include 'を入力してください'
+    describe '#likes?' do
+      context 'if the user likes the record' do
+        it 'returns true' do
+          user.like_records << record
+          expect(user.likes?(record)).to be true
+        end
+      end
+
+      context 'if the user does not like the record' do
+        it 'returns false' do
+          expect(user.likes?(record)).to be false
+        end
+      end
+    end
+
+    describe '#add_like' do
+      it 'adds a like to the user' do
+        user.add_like(record)
+        expect(user.likes?(record)).to be true
+      end
+
+      it 'does not add a duplicate like' do
+        user.add_like(record)
+        user.add_like(record)
+        expect(user.like_records.count).to eq 1
+      end
+    end
+
+    describe '#remove_like' do
+      context 'if user added a like' do
+        before { user.add_like(record) }
+
+        it 'removes the like' do
+          user.remove_like(record)
+          expect(user.likes?(record)).to be false
+        end
+      end
+
+      context 'if the like does not exist' do
+        it 'does nothing' do
+          expect { user.remove_like(record) }.to_not change(user.like_records, :count)
+        end
+      end
+    end
   end
 end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,5 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe Like, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe Like do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:other_user) }
+  let(:record) { create(:record, user: other_user) }
+
+  it 'is valid with user and record' do
+    like = user.likes.build(record: record)
+    expect(like).to be_valid
+  end
+
+  it 'is invalid without record' do
+    like = user.likes.build(record: nil)
+    like.valid?
+    expect(like.errors[:record]).to include 'を入力してください'
+  end
+
+  it 'is invalid without user' do
+    like = described_class.new(record: record, user: nil)
+    like.valid?
+    expect(like.errors[:user]).to include 'を入力してください'
+  end
 end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'Likes' do
+  describe 'POST /likes #create' do
+    let!(:other_user) { create(:other_user) }
+    let!(:record) { create(:record, user: other_user) }
+
+    context 'when not logged in' do
+      it 'redirects to login_path' do
+        post likes_path, params: { record_id: record.id }, as: :turbo_stream
+        expect(response).to redirect_to login_path
+      end
+    end
+
+    context 'when logged in' do
+      let!(:user) { create(:user) }
+
+      before do
+        log_in_as user
+      end
+
+      it 'adds like to record with Hotwire' do
+        expect {
+          post likes_path, params: { record_id: record.id }, as: :turbo_stream
+        }.to change(Like, :count).by(1)
+      end
+    end
+  end
+
+  describe 'DELETE /likes/:id #destory' do
+    let!(:user) { create(:user) }
+    let!(:record) { create(:record, user: other_user) }
+    let!(:other_user) { create(:other_user) }
+    let!(:like) { create(:like, user: user, record: record) }
+
+    context 'when not logged in' do
+      it 'redirects to login_path' do
+        delete like_path(like), as: :turbo_stream
+        expect(response).to redirect_to login_path
+      end
+    end
+
+    context 'when logged in' do
+      before do
+        log_in_as user
+      end
+
+      it 'remove like from record with Hotwire' do
+        expect {
+          delete like_path(like), as: :turbo_stream
+        }.to change(Like, :count).by(-1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
- いいね機能を追加
  - Likeモデルの作成と関連モデルの関連付け
  - Userモデルのインスタントメソッド追加
    - likes?: レコードをいいねしているか確認
    - add_like: レコードをいいねする
    - remove_like: いいねを削除する
  - Likesコントローラ作成
    - いいねを追加、削除するcreate, destoryアクション
    - 未ログインユーザーに対してレコードページのurlを保持するためのprepareアクション
  - いいねボタン作成
    - いいねの追加・削除に応じてTurboStreamでボタンを切り替え
    - いいねボタンを押したときのみアニメーションを付与
  - 追加したインスタンスメソッドとlikesコントローラを検証するspecを追加
  - いいね用にseedデータ追加
- その他
  - レコード表示ページh1タグ内の表示内容と、シェアボタンのデザイン見直し

## やっていないこと（今後実装予定）
- レコードフィードページでいいねボタンを表示する

## 動作確認
- いいねボタンを押すと、アイコンが動いていいね数が１増えること
- 再度いいねボタンを押すと、いいねが１減ること
- いいねボタンを押した状態でリロードしてもアイコンは動作しないこと

未いいね・いいね済の表示例
<img width="840" alt="image" src="https://github.com/moriw0/tyakudon/assets/87155363/fa9abecf-1827-4a48-90c5-9801599d65c4">