### PR TITLE
メインコンテンツをタブ形式で表示できるよう改善

### DIFF
--- a/app/assets/stylesheets/views/home/_favorite_records.scss
+++ b/app/assets/stylesheets/views/home/_favorite_records.scss
@@ -1,0 +1,17 @@
+@use "../../global" as g;
+
+.favorite-records {
+  .no-records {
+    text-align: center;
+    h3 {
+      font-size: 16px;
+    }
+    p {
+      font-size: 14px;
+      color: g.$brand-light-gray-color;
+      span {
+        display: inline-block;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/views/home/_index.scss
+++ b/app/assets/stylesheets/views/home/_index.scss
@@ -1,18 +1,3 @@
-@use "../../global" as g;
 @use "search";
-
-.favorite-records {
-  .no-records {
-    text-align: center;
-    h3 {
-      font-size: 16px;
-    }
-    p {
-      font-size: 14px;
-      color: g.$brand-light-gray-color;
-      span {
-        display: inline-block;
-      }
-    }
-  }
-}
+@use "tabmenu";
+@use "favorite_records";

--- a/app/assets/stylesheets/views/home/_tabmenu.scss
+++ b/app/assets/stylesheets/views/home/_tabmenu.scss
@@ -1,0 +1,30 @@
+nav.tab-menu {
+  margin-top: -40px;
+  margin-bottom: 20px;
+  ul.tabs {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    li {
+      flex: 1;
+      min-width: 70px;
+      a {
+        display: block;
+        padding: 20px 0px 10px;
+        color: #999;
+        font-weight: 600;
+        font-size: .9em;
+        text-align: center;
+        text-decoration: none;
+        &:hover {
+          color: black;
+        }
+        &.selected-tab {
+          border-bottom: 4px solid #000000;
+          color: #000000;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/views/home/_tabmenu.scss
+++ b/app/assets/stylesheets/views/home/_tabmenu.scss
@@ -11,18 +11,17 @@ nav.tab-menu {
       min-width: 70px;
       a {
         display: block;
-        padding: 20px 0px 10px;
+        padding: 10px 0;
         color: #999;
-        font-weight: 600;
-        font-size: .9em;
+        font-weight: bold;
+        font-size: 14px;
         text-align: center;
         text-decoration: none;
-        &:hover {
+        &:hover, &.selected-tab {
           color: black;
         }
         &.selected-tab {
-          border-bottom: 4px solid #000000;
-          color: #000000;
+          border-bottom: 4px solid black;
         }
       }
     }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,23 +1,17 @@
 class HomeController < ApplicationController
   include SessionsHelper
 
-  before_action :logged_in_user, only: %i[favorite_records search]
+  before_action :logged_in_user, only: %i[search]
   before_action :set_search, except: %i[search]
   before_action :disable_connect_button, only: %i[search]
-
-  def index
-    @ranking_records = Record.ranking_records.top_five
-    @new_records = Record.new_records.top_five
-    @favorite_records = Record.favorite_records_from(current_user).top_five if logged_in?
-  end
-
-  def favorite_records
-    @records = Record.favorite_records_from(current_user).page(params[:page])
-  end
 
   def record_ranking
     @records = Record.unscoped.ranking_records.page(params[:page])
     @offset = (@records.current_page - 1) * @records.limit_value
+  end
+
+  def favorite_records
+    @records = Record.favorite_records_from(current_user).page(params[:page]) if logged_in?
   end
 
   def new_records

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="tabs"
+export default class extends Controller {
+  static targets = ["tab"];
+
+  connect() {
+    this.highlightCurrentTab();
+  }
+
+  highlightCurrentTab() {
+    const currentPath = window.location.pathname;
+
+    this.tabTargets.forEach((tab) => {
+      const tabPath = tab.dataset.path;
+      tab.classList.toggle("selected-tab", tabPath === currentPath);
+    });
+  }
+}

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -27,10 +27,10 @@ class Record < ApplicationRecord
   scope :not_retired, -> { where(is_retired: false, auto_retired: false, is_test: false).where.not(wait_time: nil) }
   scope :active, -> { where(auto_retired: false, is_test: false).where.not(wait_time: nil) }
   scope :ordered_by_wait_time, -> { order('wait_time DESC') }
-  scope :ordered_by_created_at, -> { order('created_at DESC') }
+  scope :ordered_by_created_at, -> { order('records.created_at DESC') }
   scope :active_ordered, -> { active.ordered_by_created_at }
   scope :top_five, -> { limit(5) }
-  scope :with_associations, -> { preload(:user, :ramen_shop, :line_statuses, image_attachment: :blob) }
+  scope :with_associations, -> { eager_load(:user, :ramen_shop).preload(:line_statuses, image_attachment: :blob) }
 
   def self.ranking_records
     not_retired.ordered_by_wait_time.with_associations

--- a/app/views/home/_tabmenu.html.erb
+++ b/app/views/home/_tabmenu.html.erb
@@ -1,0 +1,8 @@
+<nav class="tab-menu" data-controller="tabs">
+  <ul class="tabs">
+    <li><%= link_to 'ランキング', root_path,             data: { tabs_target: "tab", path: root_path } %></li>
+    <li><%= link_to 'お気に入り', favorite_records_path, data: { tabs_target: "tab", path: favorite_records_path } %></li>
+    <li><%= link_to '新着', new_records_path,           data: { tabs_target: "tab", path: new_records_path } %></li>
+    <li><%= link_to '店舗検索', ramen_shops_path,        data: { tabs_target: "tab", path: ramen_shops_path } %></li>
+  </ul>
+</nav>

--- a/app/views/home/favorite_records.html.erb
+++ b/app/views/home/favorite_records.html.erb
@@ -1,16 +1,23 @@
 <%= render 'tabmenu' %>
 <section class="favorite-records mb-4">
-  <% if @records&.any? %>
-    <div class="records pb-2">
-      <%= render @records, name: :ramen_shop %>
-    </div>
-    <div class="d-flex justify-content-center">
-      <%= paginate @records %>
-    </div>
+  <% if logged_in? && current_user.favorite_shops.any? %>
+    <% if @records.any? %>
+      <div class="records pb-2">
+        <%= render @records, name: :ramen_shop %>
+      </div>
+      <div class="d-flex justify-content-center">
+        <%= paginate @records %>
+      </div>
+    <% else %>
+      <div class="no-records">
+        <h3>まだお気に入り店のちゃくどんがありません</h3>
+        <p><span>最初の</span><span>ちゃくどん報告をしよう！</span></p>
+      </div>
+    <% end %>
   <% else %>
     <div class="no-records">
-      <h3>まだちゃくどんレコードがありません</h3>
-      <p><span>お気に入り店の</span><span>ちゃくどん報告をしよう！</span></p>
+      <h3>まだお気に入り店の登録がありません</h3>
+      <p><span>お気に入り店舗を登録して</span><span>ちゃくどんレコードをチェックしよう！</span></p>
     </div>
   <% end %>
 </section>

--- a/app/views/home/favorite_records.html.erb
+++ b/app/views/home/favorite_records.html.erb
@@ -1,10 +1,16 @@
-<%= render 'shared/search_form' %>
-<section class="ranking mb-4">
-  <h2 class="d-flex justify-content-center py-2 mt-3">お気に入り店のちゃくどん</h2>
-  <div class="records pb-2">
-    <%= render @records, name: :ramen_shop %>
-  </div>
-  <div class="d-flex justify-content-center">
-    <%= paginate @records %>
-  </div>
+<%= render 'tabmenu' %>
+<section class="favorite-records mb-4">
+  <% if @records&.any? %>
+    <div class="records pb-2">
+      <%= render @records, name: :ramen_shop %>
+    </div>
+    <div class="d-flex justify-content-center">
+      <%= paginate @records %>
+    </div>
+  <% else %>
+    <div class="no-records">
+      <h3>まだちゃくどんレコードがありません</h3>
+      <p><span>お気に入り店の</span><span>ちゃくどん報告をしよう！</span></p>
+    </div>
+  <% end %>
 </section>

--- a/app/views/home/new_records.html.erb
+++ b/app/views/home/new_records.html.erb
@@ -1,6 +1,5 @@
-<%= render 'shared/search_form' %>
+<%= render 'tabmenu' %>
 <section class="new-records mb-3">
-  <h2 class="d-flex justify-content-center py-2 mt-3">新着ちゃくどん</h2>
   <div class="records pb-2">
     <%= render @records, name: :ramen_shop %>
   </div>

--- a/app/views/home/record_ranking.html.erb
+++ b/app/views/home/record_ranking.html.erb
@@ -1,6 +1,5 @@
-<%= render 'shared/search_form' %>
+<%= render 'tabmenu' %>
 <section class="ranking mb-4">
-  <h2 class="d-flex justify-content-center py-2 mt-3">ちゃくどんランキング</h2>
   <div class="records pb-2">
     <% @records.each_with_index do |record, index| %>
       <%= render partial: 'records/ranking_record', locals: { record: record, rank: @offset + index + 1 } %>

--- a/app/views/ramen_shops/index.html.erb
+++ b/app/views/ramen_shops/index.html.erb
@@ -1,6 +1,6 @@
+<%= render 'home/tabmenu' %>
 <%= render 'shared/search_form' %>
 <section class="shops mb-4">
-  <h2 class="d-flex justify-content-center py-2 mt-3">店舗一覧</h2>
   <div class="records list-group pb-2">
     <%= render @ramen_shops %>
   </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,5 +1,4 @@
 <section class="search mb-4">
-  <h2 class="d-flex justify-content-center py-2 mt-3">ラーメン店を探す</h2>
   <%= search_form_for @search, url: ramen_shops_path do |f| %>
     <div class="input-group">
       <%= f.search_field :name_or_address_cont, placeholder: '店名、または住所を入力', class: "form-control",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root 'home#index'
+  root 'home#record_ranking'
   get '/about', to: 'statics#about'
   get '/terms', to: 'statics#terms'
   get '/privacy_policy', to: 'statics#privacy_policy'

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -9,12 +9,6 @@ FactoryBot.define do
     ramen_shop
     user
 
-    trait :with_line_status do
-      after(:create) do |record|
-        create_list(:line_status, 1, record: record)
-      end
-    end
-
     factory :oldest do
       started_at { 1.year.ago - 10.minutes }
       ended_at { 1.year.ago }

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -9,6 +9,12 @@ FactoryBot.define do
     ramen_shop
     user
 
+    trait :with_line_status do
+      after(:create) do |record|
+        create_list(:line_status, 1, record: record)
+      end
+    end
+
     factory :oldest do
       started_at { 1.year.ago - 10.minutes }
       ended_at { 1.year.ago }

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -1,21 +1,80 @@
 require 'rails_helper'
 
 RSpec.describe 'Favorites' do
-  let(:user) { create(:user) }
-  let(:ramen_shops) { create_list(:many_shops, 5) }
+  describe 'favorite_shops page' do
+    let!(:user) { create(:user) }
+    let!(:ramen_shops) { create_list(:many_shops, 5) }
 
-  before do
-    ramen_shops.each do |ramen_shop|
-      create(:favorite, user: user, ramen_shop: ramen_shop)
+    before do
+      ramen_shops.each do |ramen_shop|
+        create(:favorite, user: user, ramen_shop: ramen_shop)
+      end
+      log_in_as(user)
     end
-    log_in_as(user)
+
+    it 'shows user favorite shops' do
+      visit favorites_by_user_path(user)
+      expect(page).to have_content '5 お気に入り店'
+      user.favorite_shops.each do |shop|
+        expect(page).to have_link href: ramen_shop_path(shop)
+      end
+    end
   end
 
-  scenario 'favorite_shops_page' do
-    visit favorites_by_user_path(user)
-    expect(page).to have_content '5 お気に入り店'
-    user.favorite_shops.each do |shop|
-      expect(page).to have_link href: ramen_shop_path(shop)
+  describe 'favorite_records page' do
+    context 'when not logged in' do
+      it 'shows there is no favorites' do
+        visit favorite_records_path
+        expect(page).to have_content 'まだお気に入り店の登録がありません'
+      end
+    end
+
+    context ['when logged in', 'with no-favorite shop'].join(', ') do
+      let!(:user) { create(:user) }
+
+      before { log_in_as user }
+
+      it 'shows there is no favorites' do
+        visit favorite_records_path
+        expect(page).to have_content 'まだお気に入り店の登録がありません'
+      end
+    end
+
+    context ['when logged in', 'with favorite shop'].join(', ') do
+      let!(:user) { create(:user) }
+      let!(:ramen_shops) { create_list(:many_shops, 5) }
+
+      before do
+        log_in_as user
+        ramen_shops.each do |ramen_shop|
+          create(:favorite, user: user, ramen_shop: ramen_shop)
+        end
+      end
+
+      context 'with no records' do
+        it 'shows there is no records' do
+          visit favorite_records_path
+          expect(page).to have_content 'まだお気に入り店のちゃくどんがありません'
+        end
+      end
+
+      context 'with favorite shop records' do
+        let!(:other_user) { create(:other_user) }
+
+        before do
+          user.favorite_shops.each do |shop|
+            create(:record, :with_line_status, ramen_shop: shop, user: other_user)
+          end
+        end
+
+        it 'shows favorite shop record links' do
+          visit favorite_records_path
+
+          Record.favorite_records_from(user) do |record|
+            expect(page).to have_link href: record_path(record)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## やったこと
- メインコンテンツをタブ形式で表示
  - tabmenuパーシャルを作成
    - タブの対象としてメインコンテンツである、ランキング・お気に入り・新着・店舗検索を表示
    - 現在表示しているページのタブは下線でハイライトする
  - homeコントローラのindexアクションを消して、root_pathをrankingアクションに変更
  - search_formパーシャルは店舗検索ページのみで表示するよう変更
  - 冗長なh2タグを削除
- その他
  - お気に入りページでは以下３パターンで表示内容を変更させるよう修正
    - 未ログインもしくは店舗のお気に入り登録がない場合
    - 店舗のお気に入り登録があっても、店舗のレコードがない場合
    - お気に入り店舗のレコードがある場合
  - お気に入りページ表示内容を検証するシステムspec追加
  - homeコントローラ用のCSSをファイル分割
  - Recordモデルのwith_associationスコープのパフォーマンスを改善

## やっていないこと（今後実装予定）
- homeコントローラのindexページは今後実装するLPに対応させる予定

## 動作確認
タブコンテンツ表示例
![image](https://github.com/moriw0/tyakudon/assets/87155363/8ee0b81f-8714-4936-a966-0aabaadb1725)

お気に入りページ表示例
![image](https://github.com/moriw0/tyakudon/assets/87155363/6582e592-a2d2-4659-88c5-569974a6273f)
