### PR TITLE
いいね数の降順ソートロジック追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,3 +90,6 @@ RSpec/MultipleMemoizedHelpers:
 # 未i18nのチェック（バリデーションエラーメッセージをi18nに登録するのはやや冗長？なためfalse）
 Rails/I18nLocaleTexts:
   Enabled: false
+
+Style/Lambda:
+  EnforcedStyle: literal

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -30,7 +30,15 @@ class Record < ApplicationRecord
   scope :ordered_by_created_at, -> { order('records.created_at DESC') }
   scope :active_ordered, -> { active.ordered_by_created_at }
   scope :top_five, -> { limit(5) }
-  scope :with_associations, -> { eager_load(:user, :ramen_shop).preload(:line_statuses, image_attachment: :blob) }
+  scope :with_associations, lambda {
+    eager_load(:user, :ramen_shop).preload(:line_statuses, :likes, image_attachment: :blob)
+  }
+  scope :with_most_likes, lambda {
+    likes_subquery = Like.group(:record_id).select('record_id, COUNT(id) AS likes_count')
+    joins("LEFT JOIN (#{likes_subquery.to_sql}) likes_subquery ON likes_subquery.record_id = records.id")
+      .select('records.*, likes_subquery.likes_count')
+      .order('likes_subquery.likes_count DESC NULLS LAST')
+  }
 
   def self.ranking_records
     not_retired.ordered_by_wait_time.with_associations

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -30,10 +30,10 @@ class Record < ApplicationRecord
   scope :ordered_by_created_at, -> { order('records.created_at DESC') }
   scope :active_ordered, -> { active.ordered_by_created_at }
   scope :top_five, -> { limit(5) }
-  scope :with_associations, lambda {
+  scope :with_associations, -> {
     eager_load(:user, :ramen_shop).preload(:line_statuses, :likes, image_attachment: :blob)
   }
-  scope :with_most_likes, lambda {
+  scope :with_most_likes, -> {
     likes_subquery = Like.group(:record_id).select('record_id, COUNT(id) AS likes_count')
     joins("LEFT JOIN (#{likes_subquery.to_sql}) likes_subquery ON likes_subquery.record_id = records.id")
       .select('records.*, likes_subquery.likes_count')

--- a/spec/factories/ramen_shops.rb
+++ b/spec/factories/ramen_shops.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     latitude { 35.7000396 }
     longitude { 139.7752222 }
 
-    factory :many_shops do
+    trait :many_shops do
       sequence(:name) { |n| "#{n}号ラーメン店" }
     end
   end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       created_at { Time.zone.now }
     end
 
-    factory :many_records do
+    trait :many_records do
       sequence(:started_at) { |n| n.minute.from_now }
       sequence(:ended_at) { |n| (n + 10).minutes.from_now }
       sequence(:created_at) { |n| n.minute.from_now }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
       activated_at { nil }
     end
 
-    factory :all_user do
+    trait :many_user do
       sequence(:name) { |n| "tester#{n}" }
       sequence(:email) { |n| "tester#{n}@example.com" }
       admin { false }

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Favorites' do
     before do
       log_in_as(user)
 
-      ramen_shops = build_stubbed_list(:many_shops, 5)
+      ramen_shops = build_stubbed_list(:ramen_shop, 5, :many_shops)
       favorites = ramen_shops.map { |shop| build_stubbed(:favorite, user: user, ramen_shop: shop) }
 
       RamenShop.insert_all ramen_shops.map(&:attributes)
@@ -49,7 +49,7 @@ RSpec.describe 'Favorites' do
       before do
         log_in_as user
 
-        ramen_shops = build_stubbed_list(:many_shops, 5)
+        ramen_shops = build_stubbed_list(:ramen_shop, 5, :many_shops)
         favorites = ramen_shops.map { |shop| build_stubbed(:favorite, user: user, ramen_shop: shop) }
 
         RamenShop.insert_all ramen_shops.map(&:attributes)

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Users' do
     let!(:non_admin) { create(:other_user) }
 
     before do
-      create_list(:all_user, 15)
+      create_list(:user, 15, :many_user)
     end
 
     context 'with admin' do
@@ -130,7 +130,7 @@ RSpec.describe 'Users' do
     end
 
     it 'shows their profile and records' do
-      create_list(:many_records, 15, user: user, ramen_shop: ramen_shop, skip_validation: true)
+      create_list(:record, 15, :many_records, user: user, ramen_shop: ramen_shop, skip_validation: true)
       create(:record, user: user, is_retired: true, ramen_shop: ramen_shop)
 
       Record.all.each do |record|


### PR DESCRIPTION
## ランキングページの実装計画
- Homeコントローラのrecord_rankingアクションをRankingRecordコントローラに移管する
- 以下ソートボタンを追加し表示内容を変更させる
  - 待ち時間(wait_time)が長い順
  - 待ち時間が短い順
  - いいね数が多い順

## やったこと
- ランキングページで追加予定のいいね数降順ソートロジック追加
- ソートロジック検証spec追加
- 関連specのリファクタリング

## 動作確認
- Rails consoleで `Record.not_retired.with_associations.with_most_likes`を実行し、いいね数の降順でソートされていることを確認