### PR TITLE
レコード一覧ページ内でも個別にいいねできるよう改善

### DIFF
--- a/app/assets/stylesheets/views/records/_shared.scss
+++ b/app/assets/stylesheets/views/records/_shared.scss
@@ -36,7 +36,7 @@ a.shop-info {
         color: gray;
       }
       div {
-        gap: 10px;
+        gap: 8px;
         .record-time {
           .hh-mm-ss {
             font-size: 24px;
@@ -57,6 +57,14 @@ a.shop-info {
         }
         .finished {
           background-color: black;
+        }
+        .like-button {
+          padding: 0;
+          background-color: transparent;
+          border: none;
+          .like-count {
+            margin-left: 3px;
+          }
         }
       }
     }

--- a/app/javascript/controllers/like_controller.js
+++ b/app/javascript/controllers/like_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="like"
+export default class extends Controller {
+  submit(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.element.requestSubmit();
+  }
+}

--- a/app/views/likes/_add_like.html.erb
+++ b/app/views/likes/_add_like.html.erb
@@ -1,6 +1,6 @@
-<%= form_with model: current_user.likes.build do |f| %>
+<%= form_with model: current_user.likes.build, data: { controller: "like", action: "click->like#submit" } do |f| %>
   <div><%= hidden_field_tag :record_id, @record.id %></div>
-  <%= f.button :type => "submit", class: 'like-button', data: { action: "click->icon#beat" } do %>
+  <%= f.button :type => "button", class: 'like-button' do %>
     <i class="fa-regular fa-thumbs-up like-icon"></i>
     <span class="like-count"><%= @record.likes.count %></span>
   <% end %>

--- a/app/views/likes/_add_like.html.erb
+++ b/app/views/likes/_add_like.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: current_user.likes.build, data: { controller: "like", action: "click->like#submit" } do |f| %>
-  <div><%= hidden_field_tag :record_id, @record.id %></div>
+  <div><%= hidden_field_tag :record_id, record.id %></div>
   <%= f.button :type => "button", class: 'like-button' do %>
     <i class="fa-regular fa-thumbs-up like-icon"></i>
-    <span class="like-count"><%= @record.likes.count %></span>
+    <span class="like-count"><%= record.likes.count %></span>
   <% end %>
 <% end %>

--- a/app/views/likes/_like_form.html.erb
+++ b/app/views/likes/_like_form.html.erb
@@ -1,4 +1,4 @@
-<div id="like_form">
+<%= tag.div id: dom_id(@record) do %>
   <% if logged_in? %>
     <% if current_user.likes?(@record) %>
       <%= render 'likes/remove_like' %>
@@ -11,4 +11,4 @@
       <span class="like-count"><%= @record.likes.count %></span>
     <% end %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/likes/_like_form.html.erb
+++ b/app/views/likes/_like_form.html.erb
@@ -1,14 +1,14 @@
-<%= tag.div id: dom_id(@record) do %>
+<%= tag.div id: dom_id(record) do %>
   <% if logged_in? %>
-    <% if current_user.likes?(@record) %>
-      <%= render 'likes/remove_like' %>
+    <% if current_user.likes?(record) %>
+      <%= render 'likes/remove_like', record: record %>
     <% else %>
-      <%= render 'likes/add_like' %>
+      <%= render 'likes/add_like', record: record %>
     <% end %>
   <% else %>
-    <%= link_to prepare_like_path(@record), class: 'like-button' do %>
+    <%= link_to prepare_like_path(record), class: 'like-button' do %>
       <i class="fa-regular fa-thumbs-up like-icon"></i>
-      <span class="like-count"><%= @record.likes.count %></span>
+      <span class="like-count"><%= record.likes.count %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/likes/_remove_like.html.erb
+++ b/app/views/likes/_remove_like.html.erb
@@ -1,6 +1,6 @@
 <% move_icon ||= false %>
-<%= form_with model: current_user.likes.find_by(record: @record), html: { method: :delete } do |f| %>
-  <%= f.button :type => "submit", class: 'like-button clicked' do %>
+<%= form_with model: current_user.likes.find_by(record: @record), html: { method: :delete, data: { controller: "like", action: "click->like#submit" } } do |f| %>
+  <%= f.button :type => "button", class: 'like-button clicked' do %>
     <i class="fa-solid fa-thumbs-up like-icon <%= 'like-beat' if move_icon %>"></i>
     <span class="like-count"><%= @record.likes.count %></span>
   <% end %>

--- a/app/views/likes/_remove_like.html.erb
+++ b/app/views/likes/_remove_like.html.erb
@@ -1,7 +1,7 @@
 <% move_icon ||= false %>
-<%= form_with model: current_user.likes.find_by(record: @record), html: { method: :delete, data: { controller: "like", action: "click->like#submit" } } do |f| %>
+<%= form_with model: current_user.likes.find_by(record: record), html: { method: :delete, data: { controller: "like", action: "click->like#submit" } } do |f| %>
   <%= f.button :type => "button", class: 'like-button clicked' do %>
     <i class="fa-solid fa-thumbs-up like-icon <%= 'like-beat' if move_icon %>"></i>
-    <span class="like-count"><%= @record.likes.count %></span>
+    <span class="like-count"><%= record.likes.count %></span>
   <% end %>
 <% end %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update @record do %>
-  <%= render partial: "remove_like", locals: { move_icon: true } %>
+  <%= render partial: "remove_like", locals: { record: @record, move_icon: true } %>
 <% end %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.update "like_form" do %>
+<%= turbo_stream.update @record do %>
   <%= render partial: "remove_like", locals: { move_icon: true } %>
 <% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.update "like_form" do %>
+<%= turbo_stream.update @record do %>
   <%= render partial: "add_like" %>
 <% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update @record do %>
-  <%= render partial: "add_like" %>
+  <%= render 'add_like', record: @record %>
 <% end %>

--- a/app/views/records/_record_overview.html.erb
+++ b/app/views/records/_record_overview.html.erb
@@ -16,5 +16,7 @@
     <% else %>
       <span class="record-status finished">ちゃくどん</span>
     <% end %>
+    <% @record = record %>
+    <%= render 'likes/like_form' %>
   </div>
 </div>

--- a/app/views/records/_record_overview.html.erb
+++ b/app/views/records/_record_overview.html.erb
@@ -16,7 +16,6 @@
     <% else %>
       <span class="record-status finished">ちゃくどん</span>
     <% end %>
-    <% @record = record %>
-    <%= render 'likes/like_form' %>
+    <%= render 'likes/like_form', record: record %>
   </div>
 </div>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -2,7 +2,7 @@
   <div class="header">
     <h1 class="record-header">ちゃくどん<span class="record-number">No. <%= @record.id %></span></h1>
     <div class="header-buttons">
-      <%= render 'likes/like_form' %>
+      <%= render 'likes/like_form', record: @record %>
       <%= link_to @tweet_url, onclick: "window.open(this.href, '_blank'); return false;", class: 'share-button' do%>
         <i class="fa-brands fa-twitter"></i>
         <span class="share-text">シェア</span>

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -6,6 +6,7 @@ module LoginSupport
       fill_in 'メールアドレス', with: user.email
       fill_in 'パスワード', with: user.password
       click_button 'ログインする'
+      expect(page).to have_content 'ログインしました'
     end
   end
 

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe 'Likes', js: true do
+  let!(:ramen_shop) { create(:ramen_shop) }
+  let!(:user) { create(:user) }
+  let!(:users) { build_stubbed_list(:user, 5, :many_user) }
+  let!(:records) { build_stubbed_list(:record, 5, :many_records, ramen_shop: ramen_shop, user: user) }
+  let!(:line_statuses) { records.map { |record| build_stubbed(:line_status, record: record) } }
+  let!(:likes) do
+    records.each_with_index.map { |record, i|
+      users.first(i).map do |user|
+        build_stubbed(:like, record: record, user: user)
+      end
+    }.flatten
+  end
+
+  # rubocop:disable Rails/SkipsModelValidations
+  before do
+    User.insert_all users.map(&:attributes)
+    Record.insert_all records.map(&:attributes)
+    LineStatus.insert_all line_statuses.map(&:attributes)
+    Like.insert_all likes.map(&:attributes)
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  context 'with all user' do
+    scenario 'user can see a record-feed order by most likes with hihlights' do
+      visit root_path
+
+      # タブとソートタイプがハイライトされていることを確認
+      expect(page).to have_selector 'a.selected-tab', text: 'ランキング'
+      expect(page).to have_selector 'a.selected-type', text: 'おそい'
+      click_link 'いいね'
+      expect(page).to have_selector 'a.selected-type', text: 'おそい'
+      expect(page).to have_selector 'a.selected-type', text: 'いいね'
+
+      # いいね数順にソートされていることを確認
+      like_counts = all('.like-count').map { |like| like.text.to_i }
+      expect(like_counts[0]).to eq 4
+      expect(like_counts[1]).to eq 3
+      expect(like_counts[2]).to eq 2
+      expect(like_counts[3]).to eq 1
+      expect(like_counts[4]).to eq 0
+    end
+  end
+
+  context 'with login other users' do
+    before { log_in_as(user) }
+
+    scenario 'user adds and removes a like in both feed page and the record page' do
+      # フィードページ
+      visit ranking_path(sort: 'most_likes')
+      top_record_id = Record.order_by_most_likes.first.id
+
+      founded_like_button = find("#record_#{top_record_id}")
+      expect(founded_like_button).to_not have_selector '.like-button.clicked'
+      expect(founded_like_button.find('.like-count').text.to_i).to eq 4
+
+      founded_like_button.click
+      founded_like_button = find("#record_#{top_record_id}")
+      expect(founded_like_button).to have_selector '.like-button.clicked'
+      expect(founded_like_button.find('.like-count').text.to_i).to eq 5
+
+      founded_like_button.click
+      founded_like_button = find("#record_#{top_record_id}")
+      expect(founded_like_button).to_not have_selector '.like-button.clicked'
+      expect(founded_like_button.find('.like-count').text.to_i).to eq 4
+
+      # レコードページ
+      top_record_link = all('.records-ranking_record').first
+      top_record_link.click
+      founded_like_button = find("#record_#{top_record_id}")
+      expect(founded_like_button).to_not have_selector '.like-button.clicked'
+      expect(founded_like_button.find('.like-count').text.to_i).to eq 4
+
+      founded_like_button.click
+      founded_like_button = find("#record_#{top_record_id}")
+      expect(founded_like_button).to have_selector '.like-button.clicked'
+      expect(founded_like_button.find('.like-count').text.to_i).to eq 5
+
+      founded_like_button.click
+      founded_like_button = find("#record_#{top_record_id}")
+      expect(founded_like_button).to_not have_selector '.like-button.clicked'
+      expect(founded_like_button.find('.like-count').text.to_i).to eq 4
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
- レコード一覧ページ内でも個別にいいねできるよう改善
  - いいね投稿フォームをjs経由でsubmitするよう変更
  - いいね投稿パーシャル内ではローカル変数を使用するよう変更
  - TurboStreamのアップデート対象としてrecordインスタンスを指定
- いいね機能のsystemスペックを追加

## 動作確認
- レコード一覧ページ内、レコードページ共にいいねを追加・解除できること
- いいね状態が一覧ページでもインタラクティブに反映されること

いいねランキングページでのいいね状態
![image](https://github.com/moriw0/tyakudon/assets/87155363/d3066f76-e625-4ede-a2fb-45e21830569e)
