### PR TITLE
未ログイン時発生のレコード一覧画面のレイアウト崩れを修正

### DIFF
--- a/app/assets/stylesheets/views/records/_shared.scss
+++ b/app/assets/stylesheets/views/records/_shared.scss
@@ -59,6 +59,7 @@ a.shop-info {
           background-color: black;
         }
         .like-button {
+          gap: 0;
           padding: 0;
           background-color: transparent;
           border: none;

--- a/app/javascript/controllers/like_controller.js
+++ b/app/javascript/controllers/like_controller.js
@@ -2,9 +2,15 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="like"
 export default class extends Controller {
+  static values = { url: String };
+
   submit(event) {
     event.preventDefault();
     event.stopPropagation();
     this.element.requestSubmit();
+  }
+
+  redirect() {
+    window.location.href = this.urlValue;
   }
 }

--- a/app/views/likes/_like_form.html.erb
+++ b/app/views/likes/_like_form.html.erb
@@ -6,9 +6,12 @@
       <%= render 'likes/add_like', record: record %>
     <% end %>
   <% else %>
-    <%= link_to prepare_like_path(record), class: 'like-button' do %>
-      <i class="fa-regular fa-thumbs-up like-icon"></i>
-      <span class="like-count"><%= record.likes.count %></span>
-    <% end %>
+    <div data-controller='like'
+      data-like-url-value=<%= prepare_like_path(record) %>
+      data-action='click->like#redirect'
+      class='like-button'>
+      <i class='fa-regular fa-thumbs-up like-icon'></i>
+      <span class='like-count'><%= record.likes.count %></span>
+    </div>
   <% end %>
 <% end %>

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe 'Likes', js: true do
       expect(like_counts[3]).to eq 1
       expect(like_counts[4]).to eq 0
     end
+
+    scenario 'user redirects to login_path when click like button' do
+      visit ranking_path(sort: 'most_likes')
+      all('.like-button').first.click
+      expect(page).to have_content 'ログインしてください'
+    end
   end
 
   context 'with login other users' do


### PR DESCRIPTION
## やったこと
fixed #111 
- 未ログイン時のいいねボタンにaタグを付与していたものをStimulusで画面遷移するよう変更
- 変更内容を検証するspecを追加

## 動作確認
未ログイン時において以下を確認
- レコード一覧画面でレイアウト崩れのないこと
- 一覧画面、レコード画面ともにいいねボタンを押すとログイン画面に遷移すること

![image](https://github.com/moriw0/tyakudon/assets/87155363/5ecf30ac-32f9-49a9-9e99-d21d809545cb)
