### PR TITLE
既にemail登録済みのユーザーによるOAuth認証対策

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,8 +26,19 @@ class SessionsController < ApplicationController
 
   def oauth_authentication(auth)
     user = User.find_by(provider: auth[:provider], uid: auth[:uid])
+
     if user
       handle_authentication(user, remember: true)
+    else
+      handle_new_oauth_user(auth)
+    end
+  end
+
+  def handle_new_oauth_user(auth)
+    existing_user = User.find_by(email: auth[:info][:email])
+
+    if existing_user
+      redirect_to login_path, notice: '既に登録されているメールアドレスです。ログインしてください。'
     else
       session['auth_data'] = auth.except('extra')
       redirect_to new_omniauth_user_path

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Sessions' do
         end
       end
 
-      context 'with existing user' do
+      context 'with existing OAuth user' do
         before do
           create(:user, provider: 'google_oauth2', uid: '123456')
         end
@@ -67,6 +67,20 @@ RSpec.describe 'Sessions' do
         it 'has a notice flash' do
           get '/auth/google_oauth2/callback'
           expect(flash[:notice]).to eq 'ログインしました'
+        end
+      end
+
+      context 'with exsting standard user' do
+        before { create(:user, email: 'oauth@example.com') }
+
+        it 'redirects to login page' do
+          get '/auth/google_oauth2/callback'
+          expect(response).to redirect_to(login_path)
+        end
+
+        it 'has a notice flash' do
+          get '/auth/google_oauth2/callback'
+          expect(flash[:notice]).to eq '既に登録されているメールアドレスです。ログインしてください。'
         end
       end
     end


### PR DESCRIPTION
## やったこと
Oauth登録をしていないemail登録済みユーザーが、Oauthでログインしようとした場合、メッセージともにログインページへ遷移するよう変更
- handle_new_oauth_userメソッドを追加
- 変更を検証するspecを追加

## 動作確認
- email登録済みユーザーでOAuthログインしようとするとログインページへ遷移すること
- eimail登録のないユーザーがOAuthログインすると新規登録ページへ遷移すること