### PR TITLE
コメント表示デザインの改善

### DIFF
--- a/app/assets/stylesheets/views/line_statuses/_line_status.scss
+++ b/app/assets/stylesheets/views/line_statuses/_line_status.scss
@@ -48,6 +48,9 @@
       padding-top: 0.5rem;
       padding-bottom: 1rem;
       .line-status-content {
+        p {
+          white-space: pre-wrap;
+        }
         .line-status-image {
           width: 100%;
           min-height: 240px;

--- a/app/assets/stylesheets/views/records/_record.scss
+++ b/app/assets/stylesheets/views/records/_record.scss
@@ -46,8 +46,13 @@
             }
             .comment-content {
               font-size: 12px;
+              display: -webkit-box;
+              overflow: hidden;
               text-align: left;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 1;
               width: 100%;
+              white-space: pre-wrap;
             }
           }
           .record-image {

--- a/app/assets/stylesheets/views/records/_show.scss
+++ b/app/assets/stylesheets/views/records/_show.scss
@@ -82,6 +82,7 @@
     .comment-content {
       text-align: left;
       width: 100%;
+      white-space: pre-wrap;
     }
     .user-info {
       text-decoration: none;


### PR DESCRIPTION
## やったこと
- 入力したスペース、改行、タブを反映して表示するようにした
- レコード一覧ページでは３行を超えるコメントは3点リーダーで非表示にした

## 動作確認
|レコード一覧|レコードページ|行列の様子|
|---|---|---|
|![image](https://github.com/moriw0/tyakudon/assets/87155363/e262a44d-0829-41d0-9317-48f2c787b575)|![image](https://github.com/moriw0/tyakudon/assets/87155363/9e0539b0-7a0d-4de2-acaa-554dc165cae1)|![image](https://github.com/moriw0/tyakudon/assets/87155363/92457748-d7e6-416d-8aed-8d3a35c69fce)|
