### PR TITLE
応援メッセージ生成プロンプトの改善

### DIFF
--- a/app/javascript/controllers/line_status_controller.js
+++ b/app/javascript/controllers/line_status_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
 
     if (lineTypeRadio.value === "seated") {
       lineNumberField.style.display = "none";
-      lineNumberInput.value = 0;
+      lineNumberInput.value = "";
     } else {
       lineNumberField.style.display = "block";
       lineNumberInput.value = "";

--- a/app/models/cheer_message.rb
+++ b/app/models/cheer_message.rb
@@ -2,14 +2,26 @@ class CheerMessage < ApplicationRecord
   belongs_to :record
   enum role: { assistant: 10, user: 20 }
 
-  scope :recent, -> { order(:created_at).last(4) }
+  scope :recent, -> { order(:created_at).last(1) }
+
+  SETTING_DESCRIPTION = <<~SETTING.freeze
+    #設定
+    userがラーメン待ちの経過時間と行列の状況について情報を提供します。
+    assistantは、その情報を元に、親しみやすく、励ましのメッセージを100文字程度で作成します。
+    各文末には極力「どん」という語尾を加えること。
+  SETTING
+
+  EXAMPLE_MESSAGES = <<~EXAMPLE.freeze
+    #例
+    user: 経過時間（分）: 30, 行列の状況: outside_the_store, 行列数: , ひとこと: 約20人に接続！
+    assistant: 30分経過して外で待っているどん！約20人に接続しているんだね！
+    お店の美味しいラーメンの香りでワクワクするね！
+    頑張って待っているあなたに、美味しいラーメンが届くように応援しているどん！
+  EXAMPLE
 
   SYSTEM_MESSAGE = {
     role: 'system',
-    content: 'あなたは次を考慮してラーメン提供を待つユーザーをメッセージで応援します。
-    ・インプット情報として、ユーザーの現時点の待ち時間（分）と行列の状況を入力する
-    ・親しみやすいメッセージを100文字以内で作成する
-    ・適宜語尾に「どんっ」を付与する'
+    content: SETTING_DESCRIPTION + EXAMPLE_MESSAGES
   }.freeze
 
   def self.for_openai(messages)
@@ -18,8 +30,12 @@ class CheerMessage < ApplicationRecord
   end
 
   def self.build_send_message(wait_time, line_status)
-    "待ち時間（分）: #{(wait_time / 60).floor},
-    行列の状況： #{line_status.line_type},
-    行列数： #{line_status.line_number}"
+    message_parts = []
+    message_parts << "経過時間（分）: #{(wait_time / 60).floor}"
+    message_parts << "行列の状況: #{line_status.line_type}"
+    message_parts << "行列数: #{line_status.line_number}" if line_status.line_number.present?
+    message_parts << "ひとこと: #{line_status.comment}" if line_status.comment.present?
+
+    message_parts.join(', ')
   end
 end

--- a/spec/system/records_spec.rb
+++ b/spec/system/records_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe 'Records', js: true do
     click_link '追加報告'
     find('label[for="line_status_line_type_outside_the_store"]').click
     fill_in '待ち行列数', with: 1
-    ## 着席を選択すると行列数が0でhiddenされる
+    ## 着席を選択すると行列数がブランクでhiddenされる
     find('label[for="line_status_line_type_seated"]').click
-    expect(find_by_id('line_status_line_number', visible: :hidden).value).to eq '0'
+    expect(find_by_id('line_status_line_number', visible: :hidden).value).to eq ''
     ## 着席以外を選択すると再び数値入力ができるようになる
     find('label[for="line_status_line_type_inside_the_store"]').click
     fill_in '待ち行列数', with: 1


### PR DESCRIPTION
## やったこと
- 応援メッセージ例を追加して、行列の様子に対する反応例を教示
- トークン数削減のため過去生成されたメッセージは引用しないよう修正
- プロンプト文をヒアドキュメントにして可読性向上
- build_send_messageメソッドはline_statusの各プロパティの存在を確認してから行列の様子情報を生成するよう修正
- 行列の様子投稿の際、seatedの行列数を0からブランクへ変更（着席時にbuild_send_messageの項目から除外するため）

## 動作確認
- 最新の行列の様子に応じて応援メッセージが生成されること
![image](https://github.com/moriw0/tyakudon/assets/87155363/9f251e74-245f-4b87-80c6-e4c97319a026)
