### PR TITLE
shop_register_requestsテーブルを作成

### DIFF
--- a/db/migrate/20240120205817_create_shop_register_requests.rb
+++ b/db/migrate/20240120205817_create_shop_register_requests.rb
@@ -1,0 +1,15 @@
+class CreateShopRegisterRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shop_register_requests do |t|
+      t.string :name, null: false
+      t.string :address, null: false
+      t.text :remarks
+      t.references :user, null: false, foreign_key: true
+      t.integer :status, null: false
+
+      t.timestamps
+    end
+
+    add_index :shop_register_requests, [:address, :name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_10_064653) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_20_205817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,6 +185,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_10_064653) do
     t.index ["user_id"], name: "index_records_on_user_id"
   end
 
+  create_table "shop_register_requests", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "address", null: false
+    t.text "remarks"
+    t.bigint "user_id", null: false
+    t.integer "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["address", "name"], name: "index_shop_register_requests_on_address_and_name", unique: true
+    t.index ["user_id"], name: "index_shop_register_requests_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -215,4 +227,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_10_064653) do
   add_foreign_key "line_statuses", "records"
   add_foreign_key "records", "ramen_shops"
   add_foreign_key "records", "users"
+  add_foreign_key "shop_register_requests", "users"
 end


### PR DESCRIPTION
## やったこと
店舗登録リクエスト機能実装のため、shop_register_requestsテーブルを作成
|カラム|用途|
|---|---|
|name|ユーザーが入力する店舗名|
|address|ユーザーが入力する店舗住所|
|remarks|ユーザーが入力する備考欄|
|status|リクエストの状態管理(enumで実装)|

## リクエスト機能の要件
- ユーザーが店舗登録リクエストボタンを押すと、以下情報を入力可能な店舗リクエストフォームを表示
    - 店名（必須）
    - 住所（必須）
    - 備考
- フォームを送信する際以下を確認
    - 店名・住所の組み合わせで重複する店舗がDBに存在しないこと
    - 店舗が存在する場合はエラーメッセージと共に店舗リンクを表示
- フォームが送信できた場合
    - 管理者へリクエスト内容通知メールを送信。
- 通知メールに記載のURLからリクエスト内容を確認し、問題なければ承認
- 承認されたらRamenShopに追加し、リクエストユーザーへ登録完了メールを送信
