### PR TITLE
エラーメッセージ表示方法の変更

### DIFF
--- a/app/controllers/ramen_shops_controller.rb
+++ b/app/controllers/ramen_shops_controller.rb
@@ -40,7 +40,7 @@ class RamenShopsController < ApplicationController
     if @ramen_shop.save
       process_after_save
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -48,7 +48,7 @@ class RamenShopsController < ApplicationController
     if @ramen_shop.update(ramen_shop_params)
       redirect_to ramen_shop_path(@ramen_shop), notice: 'saved!'
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/line_status.rb
+++ b/app/models/line_status.rb
@@ -9,8 +9,8 @@ class LineStatus < ApplicationRecord
   validates :line_number, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
   validates :comment, length: { maximum: 140, too_long: '最大%<count>s文字まで使えます' }
   validates :image, content_type: { in: %i[png jpg jpeg],
-                                    message: 'のフォーマットが不正です' },
+                                    message: :file_type_invalid },
                     size: { less_than_or_equal_to: 5.megabytes,
-                            message: 'は5MB以下である必要があります' }
+                            message: :file_size_exceed }
   default_scope { order(:id) }
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -13,9 +13,9 @@ class Record < ApplicationRecord
 
   validates :comment, length: { maximum: 140 }
   validates :image, content_type: { in: %i[png jpg jpeg],
-                                    message: 'のフォーマットが不正です' },
+                                    message: :file_type_invalid },
                     size: { less_than_or_equal_to: 5.megabytes,
-                            message: 'は5MB以下である必要があります' }
+                            message: :file_size_exceed }
   validate :started_at_is_recent,         on: :create, unless: :skip_validation
   validate :ended_at_is_recent,           on: :update, if: :calculate_action
   validate :ended_at_is_after_started_at, on: :update
@@ -90,17 +90,17 @@ class Record < ApplicationRecord
   def started_at_is_recent
     return unless started_at && (started_at - Time.current).abs > 5.seconds
 
-    errors.add(:started_at, 'は作成時の現在時刻より数秒以内でなければなりません')
+    errors.add(:started_at, :started_at_not_recent)
   end
 
   def ended_at_is_recent
     return unless ended_at && (ended_at - Time.current).abs > 5.seconds
 
-    errors.add(:ended_at, 'は更新時の現在時刻より数秒以内でなければなりません')
+    errors.add(:ended_at, :ended_at_not_recent)
   end
 
   def ended_at_is_after_started_at
-    errors.add(:ended_at, 'はstarted_atより後である必要があります。') if ended_at && started_at && ended_at <= started_at
+    errors.add(:ended_at, :ended_at_before_started_at) if ended_at && started_at && ended_at <= started_at
   end
 
   def wait_time_is_correct
@@ -108,7 +108,7 @@ class Record < ApplicationRecord
 
     return if wait_time_correct?
 
-    errors.add(:wait_time, 'はended_atとstarted_atの差である必要があります。')
+    errors.add(:wait_time, :incorrect_wait_time)
   end
 
   def wait_time_correct?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,9 +26,9 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }, allow_nil: true, unless: :uid?
 
   validates :avatar, content_type: { in: %i[png jpg jpeg],
-                                     message: 'のフォーマットが不正です' },
+                                     message: :file_type_invalid },
                      size: { less_than_or_equal_to: 5.megabytes,
-                             message: 'は5MB以下である必要があります' }
+                             message: :file_size_exceed }
 
   def self.digest(string)
     cost = if ActiveModel::SecurePassword.min_cost

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -5,6 +5,7 @@ ja:
       ramen_shop: ラーメン店
       record: ちゃくどんレコード
       line_status: 待ち行列状態
+      shop_register_requests: 店舗登録リクエスト
     attributes:
       user:
         name: ニックネーム
@@ -28,9 +29,19 @@ ja:
         line_type: タイプ
         comment: コメント
         image: 写真
+      shop_register_request:
+        name: 店名
+        address: 住所
+        remarks: 備考
   enums:
     line_status:
       line_type:
         inside_the_store: 店内
         outside_the_store: 店外
         seated: 着席
+    shop_register_request:
+      status:
+        open: 受付
+        approve: 承認
+        reject: 却下
+        complete: 完了

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -107,32 +107,46 @@ ja:
       month: 月
       year: 年
   errors:
-    format: "%{attribute}%{message}"
-    messages:
-      accepted: を受諾してください
-      blank: を入力してください
-      confirmation: と%{attribute}の入力が一致しません
-      empty: を入力してください
-      equal_to: は%{count}にしてください
-      even: は偶数にしてください
-      exclusion: は予約されています
-      greater_than: は%{count}より大きい値にしてください
-      greater_than_or_equal_to: は%{count}以上の値にしてください
-      inclusion: は一覧にありません
-      invalid: は不正な値です
-      less_than: は%{count}より小さい値にしてください
-      less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: 'バリデーションに失敗しました: %{errors}'
-      not_a_number: は数値で入力してください
-      not_an_integer: は整数で入力してください
-      odd: は奇数にしてください
-      other_than: は%{count}以外の値にしてください
-      present: は入力しないでください
-      required: を入力してください
-      taken: はすでに存在します
-      too_long: は%{count}文字以内で入力してください
-      too_short: は%{count}文字以上で入力してください
-      wrong_length: は%{count}文字で入力してください
+    format: "%{message}"
+    messages: &errors_messages
+      inclusion: "%{attribute}が正しくありません。"
+      exclusion: "%{attribute}は正しくありません。"
+      invalid: "%{attribute}が正しくありません。"
+      confirmation: "%{attribute}が一致しません。"
+      accepted: "%{attribute}をチェックしてください。"
+      empty: "%{attribute}を入力してください。"
+      blank: "%{attribute}を入力してください。"
+      required: "%{attribute}を入力してください。"
+      too_long: "%{attribute}は%{count}文字以内で入力してください。"
+      too_short: "%{attribute}は%{count}文字以上で入力してください。"
+      wrong_length: "%{attribute}は%{count}文字で入力してください。"
+      not_a_number: "%{attribute}は数値で入力してください。"
+      not_an_integer: "%{attribute}は整数で入力してください。"
+      greater_than: "%{attribute}は%{count}より大きい値を入力してください。"
+      greater_than_or_equal_to: "%{attribute}は%{count}以上の値を入力してください。"
+      equal_to: "%{attribute}は%{count}にしてください"
+      less_than: "%{attribute}は%{count}より小さい値にしてください"
+      less_than_or_equal_to: "%{attribute}は%{count}以下の値にしてください"
+      odd: "%{attribute}は奇数を入力してください。"
+      even: "%{attribute}は偶数を入力してください。"
+      taken: "%{attribute}がすでに使用されています。"
+      before: "%{attribute}は%{threshold}よりも前の%{type}を入力してください。"
+      before_or_equal_to: "%{attribute}は%{threshold}以前の%{type}を入力してください。"
+      after: "%{attribute}は%{threshold}よりも後の%{type}を入力してください。"
+      after_or_equal_to: "%{attribute}は%{threshold}以降の%{type}を入力してください。"
+      out_of_contract: "%{attribute}が契約期間外です。"
+      file_size_exceed: "%{attribute}のファイルサイズは%{max_size}以下にしてください。"
+      file_type_invalid: "アップロードできないファイル形式です。"
+      file_name_too_long: "ファイル名が長すぎます、%{count}文字以内の名称のファイルを指定してください。"
+      access_forbidden: "指定された情報にアクセスする権限がありません。"
+      pixel_size_too_large: "画像ファイルの大きさは %{width} × %{height} ピクセル以内にしてください。"
+      invalid_chars: "%{attribute}に使用できない文字が含まれています（%{chars}）。"
+      in_between: "の容量は%{min}以上%{max}以下にしてください。"
+      spoofed_media_type: "%{attribute}の拡張子と内容が一致していません。"
+      started_at_not_recent: "%{attribute}は作成時の現在時刻より数秒以内でなければなりません。"
+      ended_at_not_recent: "%{attribute}は更新時の現在時刻より数秒以内でなければなりません。"
+      ended_at_before_started_at: "%{attribute}は接続時刻より後である必要があります。"
+      incorrect_wait_time: "%{attribute}は着丼時刻と接続時刻の差である必要があります。"
     template:
       body: 次の項目を確認してください
       header:

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Favorite do
   it 'is invalid without ramen_shop' do
     favorite = user.favorites.build(ramen_shop: nil)
     favorite.valid?
-    expect(favorite.errors[:ramen_shop]).to include 'を入力してください'
+    expect(favorite.errors[:ramen_shop]).to include 'Ramen shopを入力してください。'
   end
 
   it 'is invalid without user' do
     favorite = described_class.new(ramen_shop: ramen_shop, user: nil)
     favorite.valid?
-    expect(favorite.errors[:user]).to include 'を入力してください'
+    expect(favorite.errors[:user]).to include 'Userを入力してください。'
   end
 end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Like do
 
       it 'includes error message' do
         like.valid?
-        expect(like.errors[:record]).to include 'を入力してください'
+        expect(like.errors[:record]).to include 'Recordを入力してください。'
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Like do
 
       it 'includes error message' do
         like.valid?
-        expect(like.errors[:user]).to include 'を入力してください'
+        expect(like.errors[:user]).to include 'Userを入力してください。'
       end
     end
   end

--- a/spec/models/line_status_spec.rb
+++ b/spec/models/line_status_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe LineStatus do
   it 'is invalid with string line_number' do
     line_status.line_number = '３'
     line_status.valid?
-    expect(line_status.errors[:line_number]).to include 'は数値で入力してください'
+    expect(line_status.errors[:line_number]).to include '待ち行列数は数値で入力してください。'
   end
 
   it 'is invalid with line_number less than 0' do
     line_status.line_number = -1
     line_status.valid?
-    expect(line_status.errors[:line_number]).to include 'は0以上の値にしてください'
+    expect(line_status.errors[:line_number]).to include '待ち行列数は0以上の値を入力してください。'
   end
 
   it 'is invalid with longer comment' do
@@ -45,12 +45,12 @@ RSpec.describe LineStatus do
   it 'is invalid with a 5.2 MB image' do
     line_status.image = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/1000x800_5.3MB.png').to_s)
     line_status.valid?
-    expect(line_status.errors[:image]).to include 'は5MB以下である必要があります'
+    expect(line_status.errors[:image]).to include '写真のファイルサイズは5MB以下にしてください。'
   end
 
   it 'is invalid with a gif image' do
     line_status.image = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/ramen.gif').to_s)
     line_status.valid?
-    expect(line_status.errors[:image]).to include 'のフォーマットが不正です'
+    expect(line_status.errors[:image]).to include 'アップロードできないファイル形式です。'
   end
 end

--- a/spec/models/ramen_shop_spec.rb
+++ b/spec/models/ramen_shop_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe RamenShop do
     it 'validates presence of name' do
       ramen_shop.name = nil
       ramen_shop.valid?
-      expect(ramen_shop.errors[:name]).to include('を入力してください')
+      expect(ramen_shop.errors[:name]).to include('店名を入力してください。')
     end
 
     it 'validates presence of address' do
       ramen_shop.address = nil
       ramen_shop.valid?
-      expect(ramen_shop.errors[:address]).to include('を入力してください')
+      expect(ramen_shop.errors[:address]).to include('住所を入力してください。')
     end
 
     it 'validates uniqueness of name scoped to address' do
@@ -31,19 +31,19 @@ RSpec.describe RamenShop do
       ramen_shop.name = existing_shop.name
       ramen_shop.address = existing_shop.address
       ramen_shop.valid?
-      expect(ramen_shop.errors[:name]).to include('はすでに存在します')
+      expect(ramen_shop.errors[:name]).to include('店名がすでに使用されています。')
     end
 
     it 'validates numericality of latitude' do
       ramen_shop.latitude = 91
       ramen_shop.valid?
-      expect(ramen_shop.errors[:latitude]).to include('は90以下の値にしてください')
+      expect(ramen_shop.errors[:latitude]).to include('緯度は90以下の値にしてください')
     end
 
     it 'validates numericality of longitude' do
       ramen_shop.longitude = 181
       ramen_shop.valid?
-      expect(ramen_shop.errors[:longitude]).to include('は180以下の値にしてください')
+      expect(ramen_shop.errors[:longitude]).to include('経度は180以下の値にしてください')
     end
   end
 

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:user]).to include('を入力してください')
+          expect(record.errors[:user]).to include('Userを入力してください。')
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:comment]).to include('は140文字以内で入力してください')
+          expect(record.errors[:comment]).to include('コメントは140文字以内で入力してください。')
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:image]).to include 'は5MB以下である必要があります'
+          expect(record.errors[:image]).to include '写真のファイルサイズは5MB以下にしてください。'
         end
       end
 
@@ -71,7 +71,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:image]).to include 'のフォーマットが不正です'
+          expect(record.errors[:image]).to include 'アップロードできないファイル形式です。'
         end
       end
 
@@ -80,7 +80,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:started_at]).to include('は作成時の現在時刻より数秒以内でなければなりません')
+          expect(record.errors[:started_at]).to include('接続時刻は作成時の現在時刻より数秒以内でなければなりません。')
         end
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           expect(record).to_not be_valid
-          expect(record.errors[:started_at]).to include('は作成時の現在時刻より数秒以内でなければなりません')
+          expect(record.errors[:started_at]).to include('接続時刻は作成時の現在時刻より数秒以内でなければなりません。')
         end
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:ended_at]).to include('は更新時の現在時刻より数秒以内でなければなりません')
+          expect(record.errors[:ended_at]).to include('着丼時刻は更新時の現在時刻より数秒以内でなければなりません。')
         end
       end
 
@@ -117,7 +117,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:ended_at]).to include('はstarted_atより後である必要があります。')
+          expect(record.errors[:ended_at]).to include('着丼時刻は接続時刻より後である必要があります。')
         end
       end
 
@@ -126,7 +126,7 @@ RSpec.describe Record do
 
         it 'includes error message' do
           record.valid?
-          expect(record.errors[:wait_time]).to include('はended_atとstarted_atの差である必要があります。')
+          expect(record.errors[:wait_time]).to include('待ち時間は着丼時刻と接続時刻の差である必要があります。')
         end
       end
     end

--- a/spec/models/shop_register_request_spec.rb
+++ b/spec/models/shop_register_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ShopRegisterRequest do
 
       it 'includes error message' do
         request.valid?
-        expect(request.errors[:name]).to include 'を入力してください'
+        expect(request.errors[:name]).to include '店名を入力してください。'
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe ShopRegisterRequest do
 
       it 'includes error message' do
         request.valid?
-        expect(request.errors[:address]).to include 'を入力してください'
+        expect(request.errors[:address]).to include '住所を入力してください。'
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe ShopRegisterRequest do
 
       it 'includes error message' do
         request.valid?
-        expect(request.errors[:name]).to include 'はすでに存在します'
+        expect(request.errors[:name]).to include '店名がすでに使用されています。'
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe ShopRegisterRequest do
 
       it 'includes error message' do
         request.valid?
-        expect(request.errors[:name]).to include 'は100文字以内で入力してください'
+        expect(request.errors[:name]).to include '店名は100文字以内で入力してください。'
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe ShopRegisterRequest do
 
       it 'includes error message' do
         request.valid?
-        expect(request.errors[:address]).to include 'は255文字以内で入力してください'
+        expect(request.errors[:address]).to include '住所は255文字以内で入力してください。'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,37 +19,37 @@ RSpec.describe User do
   it 'is invalid without a name' do
     user.name =  '    '
     user.valid?
-    expect(user.errors[:name]).to include('を入力してください')
+    expect(user.errors[:name]).to include('ニックネームを入力してください。')
   end
 
   it 'is invalid without an email' do
     user.email = '    '
     user.valid?
-    expect(user.errors[:email]).to include('を入力してください')
+    expect(user.errors[:email]).to include('メールアドレスを入力してください。')
   end
 
   it 'is invalid without a too long name' do
     user.name = 'a' * 51
     user.valid?
-    expect(user.errors[:name]).to include('は50文字以内で入力してください')
+    expect(user.errors[:name]).to include('ニックネームは50文字以内で入力してください。')
   end
 
   it 'is invalid without a too long email' do
     user.email = "#{'a' * 244}@example.com"
     user.valid?
-    expect(user.errors[:email]).to include('は255文字以内で入力してください')
+    expect(user.errors[:email]).to include('メールアドレスは255文字以内で入力してください。')
   end
 
   it 'is invalid with a 5.2 MB image' do
     user.avatar = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/1000x800_5.3MB.png').to_s)
     user.valid?
-    expect(user.errors[:avatar]).to include 'は5MB以下である必要があります'
+    expect(user.errors[:avatar]).to include 'アバターのファイルサイズは5MB以下にしてください。'
   end
 
   it 'is invalid with a gif image' do
     user.avatar = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/ramen.gif').to_s)
     user.valid?
-    expect(user.errors[:avatar]).to include 'のフォーマットが不正です'
+    expect(user.errors[:avatar]).to include 'アップロードできないファイル形式です。'
   end
 
   it 'is valid with valid addresses' do
@@ -77,7 +77,7 @@ RSpec.describe User do
     new_user = create(:user)
     duplicate_user = new_user.dup
     duplicate_user.valid?
-    expect(duplicate_user.errors[:email]).to include('はすでに存在します')
+    expect(duplicate_user.errors[:email]).to include('メールアドレスがすでに使用されています。')
   end
 
   it 'saves email addresses as lowercase' do
@@ -90,27 +90,26 @@ RSpec.describe User do
     it 'returns an error when the password is blank' do
       user.password = user.password_confirmation = ' ' * 6
       expect(user).to_not be_valid
-      expect(user.errors[:password]).to include('を入力してください')
+      expect(user.errors[:password]).to include('パスワードを入力してください。')
     end
 
     it 'returns an error when the password is less than 6 characters' do
       user.password = user.password_confirmation = 'a' * 5
       expect(user).to_not be_valid
-      expect(user.errors[:password]).to include('は6文字以上で入力してください')
+      expect(user.errors[:password]).to include('パスワードは6文字以上で入力してください。')
     end
 
     it 'returns an error when the password is too long' do
-      max_length = ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
-      user.password = user.password_confirmation = 'a' * (max_length + 1)
+      user.password = user.password_confirmation = 'a' * 73
       expect(user).to_not be_valid
-      expect(user.errors[:password]).to include("は#{max_length}文字以内で入力してください")
+      expect(user.errors[:password]).to include('パスワードは72文字以内で入力してください。')
     end
 
     it 'returns an error when password and password confirmation do not match' do
       user.password = 'password'
       user.password_confirmation = 'different'
       expect(user).to_not be_valid
-      expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
+      expect(user.errors[:password_confirmation]).to include('パスワードが一致しません。')
     end
 
     it 'skips password validation when uid exists' do

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Records' do
         it 'shows validation errors' do
           record_params_without_record[:record][:line_statuses_attributes][0][:line_number] = -1
           post ramen_shop_records_path(ramen_shop), params: record_params_without_record, as: :turbo_stream
-          expect(response.body).to include 'は0以上の値にしてください'
+          expect(response.body).to include '待ち行列数は0以上の値を入力してください。'
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Users' do
         attach_file 'アバター', Rails.root.join('spec/fixtures/files/1000x800_5.3MB.png'), make_visible: true
         click_button '更新する'
         expect(page).to have_content '入力してください'
-        expect(page).to have_content '5MB以下である必要があります'
+        expect(page).to have_content 'アバターのファイルサイズは5MB以下にしてください。'
       }.to_not change(User, :count)
     end
   end


### PR DESCRIPTION
## やったこと
- フォームに出現させるエラーメッセージをカラム名＋エラーメッセージとするよう変更（元：エラーメッセージのみ）
- ja.ymlの文言追加・修正
- カスタムバリデーションのエラーメッセージをja.ymlを参照するよう変更
- 変更に伴いspec修正
- その他
  - ramen_shopコントローラでエラーメッセージが表示されるようstatus追加 

## 動作確認
エラーメッセージがカラム名＋エラーメッセージであること
![image](https://github.com/moriw0/tyakudon/assets/87155363/115e06de-adb4-4335-82c6-d11a89f549d6)
