### PR TITLE
Googleログインによる新規ユーザー登録フォームの改善

### DIFF
--- a/app/assets/stylesheets/views/users/_new.scss
+++ b/app/assets/stylesheets/views/users/_new.scss
@@ -1,6 +1,10 @@
 @use "../../global/" as g;
 
 #users-new, #omniauth-users-new {
+  h1 {
+    text-align: center;
+    margin-bottom: 1.5rem;
+  }
   .agreement {
     margin-bottom: 1rem;
     label {

--- a/app/controllers/omniauth_users_controller.rb
+++ b/app/controllers/omniauth_users_controller.rb
@@ -3,9 +3,10 @@ class OmniauthUsersController < ApplicationController
 
   def new
     auth = session['auth_data']
+    nickname = auth['info']['email'].split('@').first
 
     if auth
-      @user = User.new(name: auth['info']['name'])
+      @user = User.new(name: nickname)
     else
       redirect_to root_path, alert: '不正なアクセスです'
     end

--- a/app/controllers/omniauth_users_controller.rb
+++ b/app/controllers/omniauth_users_controller.rb
@@ -11,12 +11,12 @@ class OmniauthUsersController < ApplicationController
   end
 
   def create
-    user = User.new(user_params)
-    user.build_with_omniauth(session['auth_data'])
+    @user = User.new(user_params)
+    @user.build_with_omniauth(session['auth_data'])
 
-    if user.save
-      user.activate
-      handle_authentication(user, remember: true)
+    if @user.save
+      @user.activate
+      handle_authentication(@user, remember: true)
     else
       render 'new', status: :unprocessable_entity
     end

--- a/app/controllers/omniauth_users_controller.rb
+++ b/app/controllers/omniauth_users_controller.rb
@@ -1,4 +1,6 @@
 class OmniauthUsersController < ApplicationController
+  before_action :disable_connect_button, only: %i[new]
+
   include Authenticatable
 
   def new

--- a/app/controllers/omniauth_users_controller.rb
+++ b/app/controllers/omniauth_users_controller.rb
@@ -2,14 +2,12 @@ class OmniauthUsersController < ApplicationController
   include Authenticatable
 
   def new
-    auth = session['auth_data']
-    nickname = auth['info']['email'].split('@').first
-
-    if auth
-      @user = User.new(name: nickname)
-    else
-      redirect_to root_path, alert: '不正なアクセスです'
+    unless (auth = session['auth_data'])
+      return redirect_to root_path, alert: '不正なアクセスです'
     end
+
+    email = auth['info']['email']
+    @user = User.new(email: email)
   end
 
   def create

--- a/app/views/omniauth_users/new.html.erb
+++ b/app/views/omniauth_users/new.html.erb
@@ -1,6 +1,7 @@
 <div id="omniauth-users-new">
   <h1>ユーザー登録</h1>
   <%= bootstrap_form_with model: @user, url: omniauth_users_path, html: { id: 'user-form' } do |f| %>
+    <%= f.email_field :email, label: "メールアドレス", value: @user.email, disabled: true, required: false %>
     <%= f.text_field :name, label: "ニックネーム" %>
     <%= render 'shared/image_uploader', f: f %>
     <%= render 'shared/agreement', f: f %>

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Users' do
         visit new_user_path
         click_button 'Googleアカウントでログインする'
 
-        expect(page).to have_selector("input[value='OAuth user']")
+        expect(page).to have_selector("input[value='oauth']")
         expect {
           fill_in 'ニックネーム', with: 'もりを'
           find('input#agreement').click

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe 'Users' do
         visit new_user_path
         click_button 'Googleアカウントでログインする'
 
-        expect(page).to have_selector("input[value='oauth']")
+        expect(page).to have_selector("input[type='email'][disabled][value='oauth@example.com']")
+        expect(page).to have_field('ニックネーム', with: '')
+
         expect {
           fill_in 'ニックネーム', with: 'もりを'
           find('input#agreement').click

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -28,24 +28,42 @@ RSpec.describe 'Users' do
         Rails.application.env_config.delete('omniauth.auth')
       end
 
-      scenario 'user creates an account with OAuth and logins', js: true do
-        visit new_user_path
-        click_button 'Googleアカウントでログインする'
+      context 'with valid information' do
+        scenario 'user creates an account and logins', js: true do
+          visit new_user_path
+          click_button 'Googleアカウントでログインする'
 
-        expect(page).to have_selector("input[type='email'][disabled][value='oauth@example.com']")
-        expect(page).to have_field('ニックネーム', with: '')
+          expect(page).to have_selector("input[type='email'][disabled][value='oauth@example.com']")
+          expect(page).to have_field('ニックネーム', with: '')
 
-        expect {
-          fill_in 'ニックネーム', with: 'もりを'
-          find('input#agreement').click
-          click_button '登録する'
-          expect(page).to have_content 'ログインしました'
-        }.to change(User, :count).by(1)
+          expect {
+            fill_in 'ニックネーム', with: 'もりを'
+            find('input#agreement').click
+            click_button '登録する'
+            expect(page).to have_content 'ログインしました'
+          }.to change(User, :count).by(1)
 
-        expect(User.last.email).to eq 'oauth@example.com'
-        find('label.open').click
-        click_link 'プロフィール'
-        expect(page).to have_content 'もりを'
+          expect(User.last.email).to eq 'oauth@example.com'
+          find('label.open').click
+          click_link 'プロフィール'
+          expect(page).to have_content 'もりを'
+        end
+      end
+
+      context 'with invalid information' do
+        scenario 'user does not create an account', js: true do
+          visit new_user_path
+          click_button 'Googleアカウントでログインする'
+
+          expect {
+            fill_in 'ニックネーム', with: ' '
+            find('input#agreement').click
+            click_button '登録する'
+          }.to_not change(User, :count)
+
+          expect(page).to have_content 'ニックネームを入力してください。'
+          expect(page).to have_selector("input[type='email'][disabled][value='oauth@example.com']")
+        end
       end
     end
   end


### PR DESCRIPTION
## やったこと
- Googleアカウントから取得したmailアドレスを表示するよう変更
- ニックネームフィールドは名前入力でなく、ブランクに変更
- バリデーション無効時にエラー表示できるよう修正し、検証スペックを追加
- 「現在地から接続」ボタンを表示しないよう修正

## 動作確認
変更後の登録フォーム
![image](https://github.com/moriw0/tyakudon/assets/87155363/52350aeb-2f69-467e-9d80-bcb74395a35f)
