### PR TITLE
管理者によるユーザー閲覧内容の改善

### DIFF
--- a/app/assets/stylesheets/views/users/_show_layout.scss
+++ b/app/assets/stylesheets/views/users/_show_layout.scss
@@ -15,6 +15,11 @@
         margin-bottom: 2rem;
         margin-top: 1rem;
         text-align: center;
+        .email {
+          display: block;
+          font-size: 12px;
+          margin-top: 10px;
+        }
         .not_activated_tag {
           background-color: var(--bs-code-color);
           border-radius: 20px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,8 @@ class UsersController < ApplicationController
   before_action :disable_connect_button, only: %i[new edit]
 
   def index
-    @users = User.page(params[:page])
+    @users_count = User.all.count
+    @users = User.order(created_at: :desc).page(params[:page])
   end
 
   def show

--- a/app/views/users/_show_layout.html.erb
+++ b/app/views/users/_show_layout.html.erb
@@ -6,6 +6,9 @@
       <% end %>
       <h1>
         <%= @user.name %>
+        <% if logged_in? && current_user.admin? %>
+          <span class='email'><%= @user.email if current_user.admin%></span>
+        <% end%>
         <% unless @user.activated? %>
           <span class='not_activated_tag'>アカウントが有効化されていません</span>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,4 @@
-<h1>すべてのユーザー</h1>
+<h1>すべてのユーザー (<%= @users_count %>)</h1>
 <ul class="users">
   <%= render @users %>
 </ul>

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -26,11 +26,12 @@ RSpec.describe 'Users' do
 
     context 'with admin' do
       let!(:admin) { create(:user, :admin) }
+      let(:users_count) { User.all.count }
 
       it 'gets users_path with admin' do
         log_in_as(admin)
         get users_path
-        expect(response.body).to include '<h1>すべてのユーザー</h1>'
+        expect(response.body).to include "<h1>すべてのユーザー (#{users_count})</h1>"
       end
     end
   end


### PR DESCRIPTION
## やったこと
管理者ログインでのユーザー閲覧内容の改善
- ユーザー一覧ページでユーザー総数を表示
- ユーザー一覧を登録日降順でソート
- ユーザーページでemailアドレスを表示

## 動作確認
|ユーザー一覧|ユーザーページ|
|---|---|
|![image](https://github.com/moriw0/tyakudon/assets/87155363/958a60f5-a0a1-4a50-875a-8a5a05d6ebdb)|![image](https://github.com/moriw0/tyakudon/assets/87155363/1630393e-92e4-47c0-93d6-3e07d0483973)|


