### PR TITLE
ランディングページの改善

### DIFF
--- a/app/assets/stylesheets/views/landing_page/_header.scss
+++ b/app/assets/stylesheets/views/landing_page/_header.scss
@@ -7,7 +7,7 @@
   .logo {
     width: 500px;
   }
-  .root-path-link {
+  .new-user-path-link {
     color: #e26b5d;
     display: inline-block;
     font-size: 16px;

--- a/app/assets/stylesheets/views/landing_page/_header.scss
+++ b/app/assets/stylesheets/views/landing_page/_header.scss
@@ -33,6 +33,26 @@
     }
     width: 80%;
   }
+  .todays-count {
+    color: #666;
+    font-size: 0.8em;
+    margin-bottom: 2rem;
+    .total-counts {
+      display: flex;
+      gap: 5px;
+      justify-content: center;
+      margin-top: 5px;
+      span {
+        background-color: #e26b5d;
+        border-radius: 10px;
+        color: #fff;
+        font-size: 1.5em;
+        margin: 0 5px;
+        padding: 3px 9px;
+      }
+    }
+  }
+
   @media screen and (max-width: 768px) {
     .button-big {
       width: 80%;

--- a/app/assets/stylesheets/views/landing_page/_promotion.scss
+++ b/app/assets/stylesheets/views/landing_page/_promotion.scss
@@ -8,7 +8,7 @@
         margin-bottom: 20px;
       }
       p {
-        margin-bottom: 40px;
+        margin-bottom: 1.5rem;
       }
       .begin-button {
         background-color: black;

--- a/app/assets/stylesheets/views/landing_page/_promotion.scss
+++ b/app/assets/stylesheets/views/landing_page/_promotion.scss
@@ -24,7 +24,7 @@
           width: 80%;
         }
       }
-      .root-path-link {
+      .new-user-path-link {
         color: #444;
         display: inline-block;
         font-size: 16px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   def logged_in_user
     unless logged_in?
       store_location
-      flash.alert = 'ログインしてください'
+      flash.alert = 'ログインが必要です'
       redirect_to login_path, status: :see_other
       return
     end

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -2,9 +2,14 @@ class LandingPageController < ApplicationController
   before_action :disable_connect_button
   layout 'lp'
 
+  # rubocop:disable Metrics/AbcSize
   def index
+    @today = Time.zone.today.strftime('%-m月%-d日')
+    @users_count = User.all.count
+    @records_count = Record.where(is_test: false).count
     @longest_record = Record.not_retired.with_associations.order_by_longest_wait.first
     @most_like_record = Record.not_retired.with_associations.order_by_most_likes.first
     @shortest_record = Record.not_retired.with_associations.order_by_shortest_wait.first
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -13,8 +13,7 @@
         <div><span><%= @records_count %></span>レコード</div>
       </div>
     </div>
-    <%= link_to '今すぐ始める', login_path, class: 'button-primary button-big' %>
-    <%= link_to 'トップページをのぞいてみる', ranking_path, class: 'root-path-link' %>
+    <%= link_to '今すぐ始める', ranking_path, class: 'button-primary button-big' %>
   </div>
 </section>
 <section class='youtube'>
@@ -45,7 +44,6 @@
   <div class='container'>
     <h2>新しいラーメン体験、<span>今ここから始めよう！</span></h2>
     <p>完全無料！ちゃくどんでラーメンライフを<span>もっと豊かにしましょう。</span></p>
-    <%= link_to '今すぐ始める', login_path, class: 'begin-button' %>
-    <%= link_to 'トップページをのぞいてみる', ranking_path, class: 'root-path-link' %>
+    <%= link_to '今すぐ始める', ranking_path, class: 'begin-button' %>
   </div>
 </section>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -1,6 +1,6 @@
 <section>
   <div class='header-content'>
-    <h1><span>ラーメン待ちの時間も、</span><span>楽しみの一部に。</span></h1>
+    <h1><span>ラーメン待ちの時間、</span><span>気になりませんか？</span></h1>
     <p>
       <span>接続から着丼までのラーメン待ち時間である</span>
       <span>「ちゃくどんレコード」を共有することで、</span>
@@ -42,8 +42,8 @@
 <%= render 'usage_steps' %>
 <section class='promotion'>
   <div class='container'>
-    <h2>新しいラーメン体験、<span>今ここから始めよう！</span></h2>
-    <p>完全無料！ちゃくどんでラーメンライフを<span>もっと豊かにしましょう。</span></p>
+    <h2>ちゃくどんレコードを<span>確認してみよう！</span></h2>
+    <p>完全無料！お気軽にどうぞ！</p>
     <%= link_to '今すぐ始める', ranking_path, class: 'begin-button' %>
   </div>
 </section>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -6,6 +6,13 @@
       <span>「ちゃくどんレコード」を共有することで、</span>
       <span>より快適なラーメンライフを提供します。</span>
     </p>
+    <div class="todays-count">
+      <%= @today %> 現在
+      <div class="total-counts">
+        <div><span><%= @users_count %></span>ユーザー</div>
+        <div><span><%= @records_count %></span>レコード</div>
+      </div>
+    </div>
     <%= link_to '今すぐ始める', login_path, class: 'button-primary button-big' %>
     <%= link_to 'トップページをのぞいてみる', ranking_path, class: 'root-path-link' %>
   </div>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -14,6 +14,7 @@
       </div>
     </div>
     <%= link_to '今すぐ始める', ranking_path, class: 'button-primary button-big' %>
+    <%= link_to 'ユーザー登録する', new_user_path, class: 'new-user-path-link' %>
   </div>
 </section>
 <section class='youtube'>
@@ -45,5 +46,6 @@
     <h2>ちゃくどんレコードを<span>確認してみよう！</span></h2>
     <p>完全無料！お気軽にどうぞ！</p>
     <%= link_to '今すぐ始める', ranking_path, class: 'begin-button' %>
+    <%= link_to 'ユーザー登録する', new_user_path, class: 'new-user-path-link' %>
   </div>
 </section>

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Likes', js: true do
     scenario 'user redirects to login_path when click like button' do
       visit ranking_path(sort: 'most_likes')
       all('.like-button').first.click
-      expect(page).to have_content 'ログインしてください'
+      expect(page).to have_content 'ログインが必要です'
     end
   end
 


### PR DESCRIPTION
## やったこと
- 現在登録中のユーザー数、レコード数を表示
- 「今すぐはじめる」ボタンのパスをログインページから、ランキングページへ変更（離脱改善の試み）
- 「トップページをのぞいてみる」を「ユーザー登録する」リンクへ変更
- headerセクション、promotionセクションの文言を変更
- 未ログイン時のフラッシュメッセージを変更

## 動作確認
ランディングページのユーザー数、レコード数表示
![image](https://github.com/moriw0/tyakudon/assets/87155363/3dcc25b5-8972-48aa-a567-d64628d7502f)
