### PR TITLE
Sentry関連の改善

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -26,6 +26,15 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+
       - name: Success
         uses: rtCamp/action-slack-notify@v2
         if: success()

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -5,6 +5,7 @@ class AccountActivationsController < ApplicationController
       user.activate
       log_in user
       redirect_to user, notice: 'アカウントが有効化されました'
+      capture_message_with_user_info('Standard User Created')
     else
       redirect_to root_path, alert: '無効な有効化リンクです'
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,4 +44,23 @@ class ApplicationController < ActionController::Base
   def disable_connect_button
     @show_connect_button = false
   end
+
+  def capture_message_with_user_info(message)
+    set_user_info
+    Sentry.capture_message(message, level: :info)
+  end
+
+  def set_user_info
+    Sentry.set_user(
+      id: current_user.id,
+      name: current_user.name
+    )
+
+    Sentry.configure_scope do |scope|
+      scope.set_context(
+        'user_details',
+        { user_url: user_url(current_user) }
+      )
+    end
+  end
 end

--- a/app/controllers/omniauth_users_controller.rb
+++ b/app/controllers/omniauth_users_controller.rb
@@ -13,14 +13,13 @@ class OmniauthUsersController < ApplicationController
   end
 
   def create
-    Sentry.capture_message('Omniauth User created') if Rails.env.production?
-
     @user = User.new(user_params)
     @user.build_with_omniauth(session['auth_data'])
 
     if @user.save
       @user.activate
       handle_authentication(@user, remember: true)
+      capture_message_with_user_info('Omniauth User created')
     else
       render 'new', status: :unprocessable_entity
     end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class RecordsController < ApplicationController
   include RecordsHelper
 
@@ -125,3 +126,4 @@ class RecordsController < ApplicationController
     redirect_to root_path, notice: '記録は無効になっています', status: :see_other
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -22,12 +22,11 @@ class RecordsController < ApplicationController
   end
 
   def create
-    Sentry.capture_message('Record created') if Rails.env.production?
-
     @record = Record.new(create_record_params)
 
     if @record.save
       redirect_to measure_record_path(@record), status: :see_other
+      capture_message_with_user_info('Record created')
     else
       set_ramen_shop
       render :new_with_errors, status: :unprocessable_entity
@@ -47,8 +46,6 @@ class RecordsController < ApplicationController
   end
 
   def calculate
-    Sentry.capture_message('Record calculated')
-
     if @record.ended_at?
       redirect_to root_path, status: :see_other
     else
@@ -56,6 +53,7 @@ class RecordsController < ApplicationController
       @record.update!(calculated_record_params)
       forget_record
       redirect_to result_record_path(@record), notice: 'ちゃくどんレコードを登録しました', status: :see_other
+      capture_message_with_user_info('Record Calculated')
     end
   end
 
@@ -74,6 +72,7 @@ class RecordsController < ApplicationController
     @record.calculate_wait_time_for_retire!
     forget_record
     redirect_to root_path, notice: 'リタイアしました', status: :see_other
+    capture_message_with_user_info('Record Retired')
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,6 @@ class SessionsController < ApplicationController
   end
 
   def create
-    Sentry.capture_message('Session created') if Rails.env.production?
-
     if request.env['omniauth.auth'].present?
       oauth_authentication(request.env['omniauth.auth'])
     else
@@ -31,6 +29,7 @@ class SessionsController < ApplicationController
 
     if user
       handle_authentication(user, remember: true)
+      capture_message_with_user_info('OAuth Session Created')
     else
       handle_new_oauth_user(auth)
     end
@@ -59,6 +58,7 @@ class SessionsController < ApplicationController
   def handle_successful_authentication(user)
     remember_me = params[:session][:remember_me] == '1'
     handle_authentication(user, remember: remember_me)
+    capture_message_with_user_info('Standard Session Created')
   end
 
   def handle_failed_authentication

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,8 +22,6 @@ class UsersController < ApplicationController
   end
 
   def create
-    Sentry.capture_message('User created') if Rails.env.production?
-
     @user = User.new(user_params)
 
     if @user.save

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.dsn = 'https://e54ad48a6ce26bbb08d0c1f99c6098fd@o4506884486397952.ingest.us.sentry.io/4506884486594560'
+  config.dsn = ENV['SENTRY_DSN']
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
   # To activate performance monitoring, set one of these options.
@@ -9,4 +9,7 @@ Sentry.init do |config|
   config.traces_sampler = lambda do |context|
     true
   end
+
+  config.environment = Rails.env
+  config.enabled_environments = %w[production]
 end


### PR DESCRIPTION
## やったこと
- relese名にコミットハッシュを使用するよう、デプロイワークフローを改善
- キャプチャーメッセージをアクションが成功したときのみ送信するよう変更
- capture_message_with_user_infoを追加
  - 引数に合わせてアラートメッセージを送信
  - 補足情報として、user_pathや、ユーザー名を付与
- イニシャライザの改善
  - 送信DNSは環境変数で指定するよう変更
  - 本番環境でのみ有効にするよう変更

## 動作確認
- capture_message_with_user_infoにより、指定タイミングでアラートが発信されること
- コミットハッシュを引用したrelease名が付与されること