### PR TITLE
docker compose で db のヘルスチェックを利用する

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   db:
     image: postgres:14


### PR DESCRIPTION
これまでは db を常時起動することで docker compose up したときに app が正常に立ち上がるようになっていた。
ヘルスチェックという機能を利用することで db の常時起動が不要になったため設定から除外した。
＊ docker compose は開発環境のみで使用している