### PR TITLE
接続中のレコードも表示できるようにする

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
 
   # rubocop:disable Metrics/MethodLength
   def wait_time_tag(wait_time)
-    return unless wait_time
+    return tag.span('接続中...', class: 'connecting-label') unless wait_time
 
     hours, remainder = wait_time.divmod(3600)
     minutes, remainder_seconds = remainder.divmod(60)

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -25,6 +25,7 @@ class Record < ApplicationRecord
   after_create :schedule_auto_retire
 
   scope :not_retired, -> { where(is_retired: false, auto_retired: false, is_test: false).where.not(wait_time: nil) }
+  scope :not_retired_or_connecting, -> { where(is_retired: false, auto_retired: false, is_test: false) }
   scope :active, -> { where(auto_retired: false, is_test: false).where.not(wait_time: nil) }
   scope :order_by_longest_wait, -> { order('wait_time DESC') }
   scope :order_by_shortest_wait, -> { order('wait_time ASC') }
@@ -53,7 +54,7 @@ class Record < ApplicationRecord
   end
 
   def self.new_records
-    not_retired.ordered_by_created_at.with_associations
+    not_retired_or_connecting.ordered_by_created_at.with_associations
   end
 
   def self.favorite_records_from(user)

--- a/app/views/records/_record_overview.html.erb
+++ b/app/views/records/_record_overview.html.erb
@@ -13,7 +13,7 @@
     </div>
     <% if record.is_retired? %>
       <span class="record-status retired">リタイア</span>
-    <% else %>
+    <% elsif record.wait_time.present? %>
       <span class="record-status finished">ちゃくどん</span>
     <% end %>
     <%= render 'likes/like_form', record: record %>

--- a/spec/requests/new_records_spec.rb
+++ b/spec/requests/new_records_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe 'NewRecords' do
       end
     end
 
+    context 'with connecting records' do
+      let!(:connecting_record) do
+        create(:record_only_has_started_at, :with_line_status, is_retired: false,
+                                                               ramen_shop: create(:ramen_shop, :many_shops))
+      end
+      let!(:finished_record) do
+        create(:record, :with_line_status, is_retired: false, ramen_shop: create(:ramen_shop, :many_shops))
+      end
+
+      it 'includes connecting records (wait_time is nil)' do
+        get new_records_path
+        assigned = controller.instance_variable_get(:@records)
+        expect(assigned).to include(connecting_record)
+      end
+
+      it 'includes both connecting and finished records' do
+        get new_records_path
+        assigned = controller.instance_variable_get(:@records)
+        expect(assigned).to include(connecting_record, finished_record)
+      end
+    end
+
     context 'with pagination' do
       before do
         create_list(:record, 30, :with_line_status, ramen_shop: create(:ramen_shop, :many_shops))


### PR DESCRIPTION
## Summary
- 接続中レコード（wait_timeがnil）を新記録一覧に表示
- 接続中レコードは「接続中...」表示

| 一覧画面 | 詳細画面 |
|--------|--------|
| <img width="511" height="103" alt="image" src="https://github.com/user-attachments/assets/8027a208-e14f-4f07-871f-95a4f2c9f3a0" /> | <img width="602" height="463" alt="image" src="https://github.com/user-attachments/assets/4a21868d-ddb5-4591-9a99-6350e75783cd" /> | 




🤖 Generated with [Claude Code](https://claude.com/claude-code)