### PR TITLE
Rename work flow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,4 +1,4 @@
-name: CI flow for Amazon ECS
+name: CI flow
 
 on:
   pull_request:


### PR DESCRIPTION
このプロジェクトでは Amazon ECS を使用していない。
CI flow 名に ECS が含まれていたことから、その言及をやめた。