### PR TITLE
feat: 新着一覧にリタイアレコードも表示する

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -26,6 +26,7 @@ class Record < ApplicationRecord
 
   scope :not_retired, -> { where(is_retired: false, auto_retired: false, is_test: false).where.not(wait_time: nil) }
   scope :not_retired_or_connecting, -> { where(is_retired: false, auto_retired: false, is_test: false) }
+  scope :not_auto_retired, -> { where(auto_retired: false, is_test: false) }
   scope :active, -> { where(auto_retired: false, is_test: false).where.not(wait_time: nil) }
   scope :order_by_longest_wait, -> { order('wait_time DESC') }
   scope :order_by_shortest_wait, -> { order('wait_time ASC') }
@@ -54,7 +55,7 @@ class Record < ApplicationRecord
   end
 
   def self.new_records
-    not_retired_or_connecting.ordered_by_created_at.with_associations
+    not_auto_retired.ordered_by_created_at.with_associations
   end
 
   def self.favorite_records_from(user)

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -160,10 +160,17 @@ RSpec.describe Record do
       let!(:connecting_record) do
         create(:record_only_has_started_at, is_retired: false, ramen_shop: create(:ramen_shop, :many_shops))
       end
+      let!(:retired_record) { create(:record, is_retired: true, ramen_shop: create(:ramen_shop, :many_shops)) }
+      let!(:test_record) { create(:record, is_test: true, ramen_shop: create(:ramen_shop, :many_shops)) }
 
-      it 'includes both finished and connecting records' do
+      it 'includes finished, connecting and retired records' do
         results = described_class.new_records
-        expect(results).to include(finished_record, connecting_record)
+        expect(results).to include(finished_record, connecting_record, retired_record)
+      end
+
+      it 'excludes test records' do
+        results = described_class.new_records
+        expect(results).to_not include(test_record)
       end
 
       it 'orders by created_at descending' do

--- a/spec/requests/new_records_spec.rb
+++ b/spec/requests/new_records_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'NewRecords' do
         expect(controller.instance_variable_get(:@records)).to be_present
       end
 
-      it 'only includes non-retired records' do
+      it 'includes retired records' do
         get new_records_path
         assigned = controller.instance_variable_get(:@records)
         expect(assigned).to include(active_records.first)
-        expect(assigned).to_not include(retired_record)
+        expect(assigned).to include(retired_record)
       end
 
       it 'orders by created_at descending' do


### PR DESCRIPTION
## Summary
- 新着レコード一覧 (`NewRecordsController#index`) でリタイアレコード (`is_retired`) も表示するように変更

<img width="517" height="261" alt="Screenshot 2026-02-11 at 7 07 39" src="https://github.com/user-attachments/assets/2ab44e35-02a3-4c45-b2a8-0132774f085f" />
