### PR TITLE
fix: preload user avatar in UsersController#show

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.with_attached_avatar.find(params[:id])
     @records = @user.records.with_associations.active_ordered.page(params[:page])
   end
 


### PR DESCRIPTION
Fixes TYAKUDON-4K by adding .with_attached_avatar to preload the user's own avatar when loading the user profile page.

This fixes N+1 query that occurs when the view displays the user's avatar in the profile header (via avatar_for helper in _show_layout.html.erb).

Previous commit (a2385cf) fixed N+1 for records' associations, but the user's own avatar was still causing an additional query.