### PR TITLE
fix: eliminate N+1 queries for user in RamenShopsController#index

### DIFF
--- a/app/models/ramen_shop.rb
+++ b/app/models/ramen_shop.rb
@@ -10,7 +10,7 @@ class RamenShop < ApplicationRecord
   validates :address, presence: true
   validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }, allow_blank: true
   validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }, allow_blank: true
-  scope :with_associations, -> { preload(records: :line_statuses) }
+  scope :with_associations, -> { preload(records: %i[user line_statuses]) }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name address]


### PR DESCRIPTION
## Summary

- Fixes Sentry issue **TYAKUDON-4R**: N+1 queries when loading user data in `RamenShopsController#index`
- Updated `RamenShop.with_associations` scope to preload user records
- Prevents repeated database queries for user information in shop list view

## Changes

**File**: `app/models/ramen_shop.rb`

```ruby
# Before
scope :with_associations, -> { preload(records: :line_statuses) }

# After
scope :with_associations, -> { preload(records: [:user, :line_statuses]) }
```

## Problem

Sentry detected N+1 queries with the pattern:
```sql
SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2
```

This occurred because:
1. `RamenShopsController#index` loads shops with `@ramen_shops = @search.result.with_associations.page(params[:page])`
2. The `with_associations` scope only preloaded `records` and `line_statuses`
3. When views accessed `record.user`, it triggered individual queries for each record

## Solution

Added `:user` to the preload list in the `with_associations` scope. This ensures user data is loaded in a single batch query along with records and line_statuses.

## Impact

- ✅ Eliminates N+1 queries for user data in shop index page
- ✅ Reduces database queries from N+1 to 1 for user loading
- ✅ Improves page load performance for shop listings

## Test Plan

- [ ] Load shop index page: https://tyakudon.com/ramen_shops
- [ ] Verify no N+1 queries in Sentry for TYAKUDON-4R
- [ ] Check page loads correctly with shop records displayed
- [ ] Monitor application logs for query count reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)