### PR TITLE
chore: upgrade PostgreSQL from 14 to 16

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         ports:
           - 5432:5432
         env:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:14
+    image: postgres:16
     volumes:
       - postgresql-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
## Summary
PostgreSQL 14から16へのアップグレード（Phase 1/6完了）

## Changes
- `compose.yaml`: postgres:14 → postgres:16
- `.github/workflows/ci-workflow.yml`: postgres → postgres:16（明示的にバージョン指定）

## Test Results
✅ All tests passing: **334 examples, 0 failures**

## Benefits
- **バージョン統一**: 開発環境とCI環境のPostgreSQLバージョンを一致
- **再現性向上**: CI実行ごとにバージョンが変わらない
- **予測可能性**: 新バージョンの破壊的変更を回避

## Migration Process
1. ✅ データベースバックアップ作成
2. ✅ compose.yaml更新
3. ✅ データベース再作成・マイグレーション・シード投入
4. ✅ PostgreSQL 16.11動作確認
5. ✅ 全テスト実行・合格
6. ✅ CI設定更新

## Verification
```bash
# PostgreSQL version check
docker compose exec db psql -U postgres -c "SELECT version();"
# => PostgreSQL 16.11

# Test results
docker compose exec app bundle exec rspec
# => 334 examples, 0 failures, 5 pending
```

## Next Steps
このPRはバージョンアップ計画（Phase 1-6）の第1段階です。
残りのPhaseは別PRで段階的に実施します：

- Phase 2: Ruby 3.2.2 → 3.3.6
- Phase 3: Rails 7.0.4 → 7.2.x
- Phase 4: 重要gemの更新
- Phase 5: Rails 8.0（オプショナル、スキップ推奨）
- Phase 6: 本番PostgreSQL更新（最後に実施）

詳細: https://github.com/moriw0/tyakudon/issues/179

---

🤖 Part of version upgrade project (Phase 1/6)