### PR TITLE
Bump ransack from 4.0.0 to 4.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "bootstrap"
 gem "jquery-rails"
 gem 'enum_help'
 gem 'kaminari'
-gem 'ransack'
+gem 'ransack', '< 4.3'
 gem "bootstrap_form"
 gem 'faker'
 gem 'seed-fu'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (4.0.0)
+    ransack (4.2.1)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
@@ -521,7 +521,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
-  ransack
+  ransack (< 4.3)
   rspec-rails
   rubocop
   rubocop-performance


### PR DESCRIPTION
## Summary

- Upgrade ransack from 4.0.0 to 4.2.1 in preparation for Rails 7.1 compatibility
- Pin version to `< 4.3` to avoid breaking changes
- Run with: `docker compose exec app bundle update --conservative ransack`

## References

- https://github.com/activerecord-hackery/ransack/blob/main/CHANGELOG.md