### PR TITLE
refactor: breadcrumb_home翻訳をsharedに統合

### DIFF
--- a/app/assets/stylesheets/v2.css
+++ b/app/assets/stylesheets/v2.css
@@ -135,6 +135,10 @@ h2 { font-size: 1.2em; }
 .form-inline { display: inline; }
 
 /* パンくずリスト */
+nav[aria-label="Breadcrumb"] {
+  margin-top: 1rem;
+}
+
 ol.breadcrumb {
   list-style: none;
   padding: 0;

--- a/app/views/announcements/index.html+v2.erb
+++ b/app/views/announcements/index.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/announcements/show.html+v2.erb
+++ b/app/views/announcements/show.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <% add_breadcrumb t('.breadcrumb_index'), announcements_path %>
 <% add_breadcrumb @announcement.title %>
 <hr>

--- a/app/views/faqs/index.html+v2.erb
+++ b/app/views/faqs/index.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/faqs/show.html+v2.erb
+++ b/app/views/faqs/show.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <% add_breadcrumb t('.breadcrumb_index'), faqs_path %>
 <% add_breadcrumb @faq.question %>
 <hr>

--- a/app/views/favorite_records/index.html+v2.erb
+++ b/app/views/favorite_records/index.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/new_records/index.html+v2.erb
+++ b/app/views/new_records/index.html+v2.erb
@@ -1,3 +1,6 @@
+<% add_breadcrumb t('shared.breadcrumb_home') %>
+<hr>
+
 <%= render 'shared/nav' %>
 <hr>
 

--- a/app/views/password_resets/edit.html+v2.erb
+++ b/app/views/password_resets/edit.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/password_resets/new.html+v2.erb
+++ b/app/views/password_resets/new.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/ramen_shops/index.html+v2.erb
+++ b/app/views/ramen_shops/index.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/ramen_shops/near_shops.html+v2.erb
+++ b/app/views/ramen_shops/near_shops.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/ramen_shops/show.html+v2.erb
+++ b/app/views/ramen_shops/show.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <% add_breadcrumb t('.breadcrumb_list'), ramen_shops_path %>
 <% add_breadcrumb @ramen_shop.name %>
 <hr>

--- a/app/views/records/result.html+v2.erb
+++ b/app/views/records/result.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <% add_breadcrumb @ramen_shop.name, @ramen_shop %>
 <% add_breadcrumb t('.breadcrumb_result') %>
 <hr>

--- a/app/views/records/show.html+v2.erb
+++ b/app/views/records/show.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <% add_breadcrumb @record.ramen_shop.name, @record.ramen_shop %>
 <% add_breadcrumb "#{t('.heading')} No.#{@record.id}" %>
 <hr>

--- a/app/views/sessions/new.html+v2.erb
+++ b/app/views/sessions/new.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/shared/_nav.html+v2.erb
+++ b/app/views/shared/_nav.html+v2.erb
@@ -1,14 +1,14 @@
 <p>
-  <% if remember_record? %>
-    <%= link_to t('.active_record'), measure_record_path(fetch_record_id) %>
-  <% else %>
-    <button data-controller="geolocation" data-action="click->geolocation#navigate" class="btn-link"><%= t('.connect') %></button>
-  <% end %>
-  | <%= link_to t('.home'), root_path %>
+  <%= link_to t('.home'), root_path %>
   | <%= link_to t('.search'), ramen_shops_path %>
   <% if logged_in? %>
     | <%= link_to t('.favorite_records'), favorite_records_path %>
     | <%= link_to current_user.name, current_user %>
+    <% if remember_record? %>
+      | <%= link_to t('.active_record'), measure_record_path(fetch_record_id) %>
+    <% else %>
+      | <button data-controller="geolocation" data-action="click->geolocation#navigate" class="btn-link"><%= t('.connect') %></button>
+    <% end %>
   <% else %>
     | <%= link_to t('.sign_up'), new_user_path %>
     | <%= link_to t('.login'), login_path %>

--- a/app/views/statics/privacy_policy.html+v2.erb
+++ b/app/views/statics/privacy_policy.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/statics/terms.html+v2.erb
+++ b/app/views/statics/terms.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/users/favorite_shops.html+v2.erb
+++ b/app/views/users/favorite_shops.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <% add_breadcrumb @user.name, @user %>
 <% add_breadcrumb t('.breadcrumb_title') %>
 <hr>

--- a/app/views/users/new.html+v2.erb
+++ b/app/views/users/new.html+v2.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/app/views/users/show.html+v2.erb
+++ b/app/views/users/show.html+v2.erb
@@ -1,5 +1,4 @@
-<% add_breadcrumb t('.breadcrumb_home'), root_path %>
-<% add_breadcrumb t('.breadcrumb_title') %>
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
 <hr>
 
 <%= render 'shared/nav' %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -1,13 +1,11 @@
 ja:
   announcements:
     index:
-      breadcrumb_home: "着丼"
       heading: "お知らせ"
       date_header: "日付"
       title_header: "タイトル"
       no_announcements: "お知らせはありません"
     show:
-      breadcrumb_home: "着丼"
       breadcrumb_index: "お知らせ"
       back_to_index: "お知らせ一覧に戻る"
 
@@ -36,7 +34,6 @@ ja:
 
   sessions:
     new:
-      breadcrumb_home: "着丼"
       heading: "ログイン"
       email_label: "メールアドレス"
       password_label: "パスワード"
@@ -47,17 +44,16 @@ ja:
 
   statics:
     terms:
-      breadcrumb_home: "着丼"
       heading: "利用規約"
     privacy_policy:
-      breadcrumb_home: "着丼"
       heading: "プライバシーポリシー"
 
   shared:
+    breadcrumb_home: "着丼"
     nav:
       active_record: "接続中記録"
       connect: "現在地から接続"
-      home: "ホーム"
+      home: "新着記録"
       search: "店舗検索"
       favorite_records: "お気に入り店舗"
       sign_up: "ユーザー登録"
@@ -70,14 +66,12 @@ ja:
 
   password_resets:
     new:
-      breadcrumb_home: "着丼"
       heading: "パスワード再設定"
       description: "メールアドレスへパスワード再設定用のリンクを送付します。"
       email_label: "メールアドレス"
       submit: "再設定用リンクを申請する"
       back_to_login: "ログインへ戻る"
     edit:
-      breadcrumb_home: "着丼"
       heading: "パスワード再設定"
       password_label: "パスワード"
       password_hint: "半角英数字6文字以上"
@@ -97,7 +91,6 @@ ja:
       queue_section: "行列状況"
       add_report_link: "追加報告"
     result:
-      breadcrumb_home: "着丼"
       breadcrumb_result: "着丼記録"
       heading: "着丼記録"
       shop_label: "店舗名"
@@ -110,7 +103,6 @@ ja:
       submit: "投稿する"
       queue_section: "行列状況"
     show:
-      breadcrumb_home: "着丼"
       heading: "着丼記録"
       shop_label: "店舗名"
       wait_time_label: "待ち時間"
@@ -150,12 +142,10 @@ ja:
 
   faqs:
     index:
-      breadcrumb_home: "着丼"
       heading: "FAQ"
       detail_link: "詳細を見る"
       new_faq: "新しい質問を追加する"
     show:
-      breadcrumb_home: "着丼"
       breadcrumb_index: "FAQ"
       back_to_index: "FAQに戻る"
       edit: "編集"
@@ -164,7 +154,6 @@ ja:
 
   ramen_shops:
     index:
-      breadcrumb_home: "着丼"
       heading: "店舗検索"
       search_placeholder: "店名または住所"
       search_button: "検索"
@@ -175,7 +164,6 @@ ja:
       no_shops: "店舗が見つかりませんでした"
       register_request_link: "店舗登録をリクエストする"
     show:
-      breadcrumb_home: "着丼"
       breadcrumb_list: "店舗一覧"
       shop_info_section: "店舗情報"
       shop_name_label: "店舗名"
@@ -191,7 +179,6 @@ ja:
       retired_label: "[リタイア]"
       no_records: "まだ着丼記録がありません"
     near_shops:
-      breadcrumb_home: "着丼"
       heading: "現在地周辺の店舗"
       shop_name_header: "店舗名"
       distance_header: "距離"
@@ -210,7 +197,6 @@ ja:
 
   favorite_records:
     index:
-      breadcrumb_home: "着丼"
       heading: "お気に入り店舗の記録"
       not_logged_in: "ログインしてお気に入り店舗の着丼記録を確認しましょう"
       no_favorites: "まだお気に入り店舗が登録されていません"
@@ -228,7 +214,6 @@ ja:
 
   users:
     new:
-      breadcrumb_home: "着丼"
       heading: "ユーザー登録"
       name_label: "ニックネーム"
       email_label: "メールアドレス"
@@ -236,7 +221,6 @@ ja:
       password_hint: "半角英数字6文字以上"
       password_confirmation_label: "パスワード（確認）"
     favorite_shops:
-      breadcrumb_home: "着丼"
       breadcrumb_title: "お気に入り店舗"
       heading: "お気に入り店舗"
       shop_name_header: "店舗名"
@@ -244,8 +228,6 @@ ja:
       no_record: "記録なし"
       no_shops: "まだお気に入りの店舗がありません"
     show:
-      breadcrumb_home: "着丼"
-      breadcrumb_title: "ユーザー"
       email_label: "メールアドレス"
       records_count_label: "記録数"
       favorite_shops_label: "お気に入り店"


### PR DESCRIPTION
## Summary

- 各ビューに重複していた `breadcrumb_home: "着丼"` 翻訳（18箇所）を `shared.breadcrumb_home` に一元化
- 全ビューで `t('.breadcrumb_home')` → `t('shared.breadcrumb_home')` に変更
- パンくずリストの上マージンを確保（`margin-top: 1rem`）
- ナビゲーションのリンク順序を変更（「新着記録」を先頭に移動）

## Test plan

- [ ] 各ページでパンくずリストに「着丼」が表示されること
- [ ] パンくずリストの上部に適切な余白があること
- [ ] ナビゲーションのリンク順序が正しいこと（新着記録 | 現在地から接続 | ...）