### PR TITLE
feat: スマホテーブルを列非表示から横スクロール対応に変更

### DIFF
--- a/app/assets/stylesheets/v2.css
+++ b/app/assets/stylesheets/v2.css
@@ -157,6 +157,11 @@ ol.breadcrumb li + li::before {
 /* テーブル横スクロールラッパー */
 .table-scroll {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-scroll table {
+  white-space: nowrap;
 }
 
 /* ページネーション（Kaminari） */
@@ -189,16 +194,9 @@ nav ul.pagination li.disabled span {
 }
 
 
-/* レスポンシブ: 480px 以下で非表示にする列 */
+/* レスポンシブ: 480px 以下 */
 @media (max-width: 480px) {
   body { font-size: 14px; }
   th, td { padding: 5px 6px; }
   th.col-th { width: 90px; } /* 縦テーブルのth固定幅 */
-
-  .col-author  { display: none; }
-  .col-comment { display: none; }
-  .col-photo   { display: none; }
-  .col-genre   { display: none; }
-  .col-queue   { display: none; }
-  .col-detail  { display: none; }
 }


### PR DESCRIPTION
## Summary

- モバイル（480px以下）でテーブルの一部列を非表示にしていた `display: none` ルールを削除
- 既存の `.table-scroll`（`overflow-x: auto`）による横スクロールで全列を確認できるように変更
- `.table-scroll table` に `white-space: nowrap` を追加してセル内折り返しを防止
- `-webkit-overflow-scrolling: touch` でiOSの慣性スクロールを有効化

## 影響範囲

`app/assets/stylesheets/v2.css` のみ。ビュー側の変更なし。
全テーブルは既に `<div class="table-scroll">` で囲まれていたため、CSSの変更だけで対応完了。

## Test plan

- [ ] DevToolsでモバイル幅（375px / iPhone SE）に切り替え
- [ ] テーブルが表示されるページ（`/`, `/ramen_shops/:id`, `/records` など）で全列が表示されること
- [ ] テーブルを横にスワイプして全列がスクロールで確認できること