### PR TITLE
feat: 記録一覧テーブルに写真サムネイル列を追加

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -4,6 +4,7 @@ class Record < ApplicationRecord
   has_many :line_statuses, dependent: :destroy
   has_one_attached :image do |attachable|
     attachable.variant :display, resize_to_limit: [750, 750]
+    attachable.variant :thumb, resize_to_fill: [104, 104]
   end
   has_many :likes, dependent: :destroy
   has_many :cheer_messages, dependent: :destroy

--- a/app/views/favorite_records/index.html+v2.erb
+++ b/app/views/favorite_records/index.html+v2.erb
@@ -26,7 +26,7 @@
             <th scope="col"><%= t('.wait_time_header') %></th>
             <th scope="col" class="col-genre"><%= t('.status_header') %></th>
             <th scope="col"><%= t('.datetime_header') %></th>
-            <th scope="col"><%= t('.photo_header') %></th>
+            <th scope="col"><%= t('shared.photo_header') %></th>
           </tr>
         </thead>
         <tbody>
@@ -36,15 +36,7 @@
               <td><%= link_to format_wait_time_human(record.wait_time), record_path(record) %></td>
               <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
               <td><%= format_datetime(record.started_at) %></td>
-              <td>
-                <% if record.image.attached? %>
-                  <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
-                    <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
-                  <% end %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
+              <%= render 'records/photo_thumb', record: record %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/favorite_records/index.html+v2.erb
+++ b/app/views/favorite_records/index.html+v2.erb
@@ -26,6 +26,7 @@
             <th scope="col"><%= t('.wait_time_header') %></th>
             <th scope="col" class="col-genre"><%= t('.status_header') %></th>
             <th scope="col"><%= t('.datetime_header') %></th>
+            <th scope="col"><%= t('.photo_header') %></th>
           </tr>
         </thead>
         <tbody>
@@ -35,6 +36,15 @@
               <td><%= link_to format_wait_time_human(record.wait_time), record_path(record) %></td>
               <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
               <td><%= format_datetime(record.started_at) %></td>
+              <td>
+                <% if record.image.attached? %>
+                  <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
+                    <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
+                  <% end %>
+                <% else %>
+                  -
+                <% end %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/new_records/_records_table.html+v2.erb
+++ b/app/views/new_records/_records_table.html+v2.erb
@@ -9,6 +9,7 @@
           <th scope="col" class="col-genre"><%= t('new_records.index.status_header') %></th>
           <th scope="col"><%= t('new_records.index.datetime_header') %></th>
           <th scope="col" class="col-author"><%= t('new_records.index.author_header') %></th>
+          <th scope="col"><%= t('new_records.index.photo_header') %></th>
         </tr>
       </thead>
       <tbody>
@@ -25,6 +26,15 @@
             <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-author"><%= link_to record.user.name, record.user %></td>
+            <td>
+              <% if record.image.attached? %>
+                <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
+                  <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
+                <% end %>
+              <% else %>
+                -
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/new_records/_records_table.html+v2.erb
+++ b/app/views/new_records/_records_table.html+v2.erb
@@ -9,7 +9,7 @@
           <th scope="col" class="col-genre"><%= t('new_records.index.status_header') %></th>
           <th scope="col"><%= t('new_records.index.datetime_header') %></th>
           <th scope="col" class="col-author"><%= t('new_records.index.author_header') %></th>
-          <th scope="col"><%= t('new_records.index.photo_header') %></th>
+          <th scope="col"><%= t('shared.photo_header') %></th>
         </tr>
       </thead>
       <tbody>
@@ -26,15 +26,7 @@
             <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-author"><%= link_to record.user.name, record.user %></td>
-            <td>
-              <% if record.image.attached? %>
-                <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
-                  <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
-                <% end %>
-              <% else %>
-                -
-              <% end %>
-            </td>
+            <%= render 'records/photo_thumb', record: record %>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/ramen_shops/show.html+v2.erb
+++ b/app/views/ramen_shops/show.html+v2.erb
@@ -45,7 +45,7 @@
           <th scope="col"><%= t('.datetime_header') %></th>
           <th scope="col" class="col-author"><%= t('.recorder_header') %></th>
           <th scope="col" class="col-comment"><%= t('.comment_header') %></th>
-          <th scope="col"><%= t('.photo_header') %></th>
+          <th scope="col"><%= t('shared.photo_header') %></th>
         </tr>
       </thead>
       <tbody>
@@ -59,15 +59,7 @@
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-author"><%= link_to record.user.name, user_path(record.user) %></td>
             <td class="col-comment"><%= record.comment.presence || '-' %></td>
-            <td>
-              <% if record.image.attached? %>
-                <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
-                  <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
-                <% end %>
-              <% else %>
-                -
-              <% end %>
-            </td>
+            <%= render 'records/photo_thumb', record: record %>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/ramen_shops/show.html+v2.erb
+++ b/app/views/ramen_shops/show.html+v2.erb
@@ -45,6 +45,7 @@
           <th scope="col"><%= t('.datetime_header') %></th>
           <th scope="col" class="col-author"><%= t('.recorder_header') %></th>
           <th scope="col" class="col-comment"><%= t('.comment_header') %></th>
+          <th scope="col"><%= t('.photo_header') %></th>
         </tr>
       </thead>
       <tbody>
@@ -58,6 +59,15 @@
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-author"><%= link_to record.user.name, user_path(record.user) %></td>
             <td class="col-comment"><%= record.comment.presence || '-' %></td>
+            <td>
+              <% if record.image.attached? %>
+                <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
+                  <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
+                <% end %>
+              <% else %>
+                -
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/records/_photo_thumb.html.erb
+++ b/app/views/records/_photo_thumb.html.erb
@@ -1,0 +1,9 @@
+<td>
+  <% if record.image.attached? %>
+    <%= image_tag record.image.variant(:thumb),
+                  class: 'thumb',
+                  alt: t('shared.photo_thumb_alt', shop_name: record.ramen_shop.name) %>
+  <% else %>
+    -
+  <% end %>
+</td>

--- a/app/views/users/show.html+v2.erb
+++ b/app/views/users/show.html+v2.erb
@@ -52,6 +52,7 @@
           <th scope="col"><%= t('.wait_time_header') %></th>
           <th scope="col"><%= t('.datetime_header') %></th>
           <th scope="col" class="col-genre"><%= t('.status_header') %></th>
+          <th scope="col"><%= t('.photo_header') %></th>
         </tr>
       </thead>
       <tbody>
@@ -61,6 +62,15 @@
             <td><%= link_to format_wait_time_human(record.wait_time), record_path(record, back: 'user') %></td>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
+            <td>
+              <% if record.image.attached? %>
+                <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
+                  <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
+                <% end %>
+              <% else %>
+                -
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/users/show.html+v2.erb
+++ b/app/views/users/show.html+v2.erb
@@ -52,7 +52,7 @@
           <th scope="col"><%= t('.wait_time_header') %></th>
           <th scope="col"><%= t('.datetime_header') %></th>
           <th scope="col" class="col-genre"><%= t('.status_header') %></th>
-          <th scope="col"><%= t('.photo_header') %></th>
+          <th scope="col"><%= t('shared.photo_header') %></th>
         </tr>
       </thead>
       <tbody>
@@ -62,15 +62,7 @@
             <td><%= link_to format_wait_time_human(record.wait_time), record_path(record, back: 'user') %></td>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
-            <td>
-              <% if record.image.attached? %>
-                <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
-                  <%= image_tag record.image.variant(:thumb), class: 'thumb', alt: '' %>
-                <% end %>
-              <% else %>
-                -
-              <% end %>
-            </td>
+            <%= render 'records/photo_thumb', record: record %>
           </tr>
         <% end %>
       </tbody>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -220,6 +220,7 @@ ja:
       wait_time_header: "待ち時間"
       datetime_header: "接続日時"
       status_header: "状況"
+      photo_header: "写真"
       no_records: "まだお気に入り店の着丼記録がありません"
     filter_form:
       heading: "絞り込む"

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -260,6 +260,7 @@ ja:
       wait_time_header: "待ち時間"
       datetime_header: "接続日時"
       status_header: "接続行列"
+      photo_header: "写真"
       no_records: "まだ着丼記録がありません"
       logout: "ログアウトする"
       logout_confirm: "本当にログアウトしますか？"

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -190,6 +190,7 @@ ja:
       comment_header: "コメント"
       datetime_header: "接続日時"
       retired_label: "[リタイア]"
+      photo_header: "写真"
       no_records: "まだ着丼記録がありません"
     near_shops:
       breadcrumb_home: "着丼"

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -20,7 +20,6 @@ ja:
       author_header: "記録者"
       status_header: "接続行列"
       connecting: "接続中"
-      photo_header: "写真"
       no_records: "記録がありません"
 
   layouts:
@@ -55,6 +54,8 @@ ja:
       heading: "プライバシーポリシー"
 
   shared:
+    photo_header: "写真"
+    photo_thumb_alt: "%{shop_name} の写真"
     nav:
       active_record: "接続中記録"
       connect: "現在地から接続"
@@ -190,7 +191,6 @@ ja:
       comment_header: "コメント"
       datetime_header: "接続日時"
       retired_label: "[リタイア]"
-      photo_header: "写真"
       no_records: "まだ着丼記録がありません"
     near_shops:
       breadcrumb_home: "着丼"
@@ -221,7 +221,6 @@ ja:
       wait_time_header: "待ち時間"
       datetime_header: "接続日時"
       status_header: "状況"
-      photo_header: "写真"
       no_records: "まだお気に入り店の着丼記録がありません"
     filter_form:
       heading: "絞り込む"
@@ -262,7 +261,6 @@ ja:
       wait_time_header: "待ち時間"
       datetime_header: "接続日時"
       status_header: "接続行列"
-      photo_header: "写真"
       no_records: "まだ着丼記録がありません"
       logout: "ログアウトする"
       logout_confirm: "本当にログアウトしますか？"

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -20,6 +20,7 @@ ja:
       author_header: "記録者"
       status_header: "接続行列"
       connecting: "接続中"
+      photo_header: "写真"
       no_records: "記録がありません"
 
   layouts:


### PR DESCRIPTION
## Summary

- `Record` モデルに一覧表示用の `:thumb` variant（104×104px）を追加
- 新着記録・ユーザー詳細・お気に入り一覧・店舗詳細の4ページに写真列を追加
- サムネイルブロックを `records/_photo_thumb` パーシャルに集約（DRY化）
- alt テキストに店舗名を含む contextual な文字列を設定（アクセシビリティ改善）
- `photo_header` 翻訳キーを `shared` に統合（ロケール重複解消）

## Test plan

- [ ] `/` 新着記録一覧に「写真」列が表示される
- [ ] `/users/:id` ユーザー詳細の記録一覧に「写真」列が表示される
- [ ] `/favorite_records` お気に入り一覧に「写真」列が表示される
- [ ] `/ramen_shops/:id` 店舗詳細の記録一覧に「写真」列が表示される
- [ ] 写真付きレコード: 52×52 サムネイルが表示される
- [ ] 写真なしレコード: `-` が表示される
- [ ] モバイル幅でテーブルが横スクロールで表示される