### PR TITLE
feat: テーブルのサムネイルクリックでオリジナル画像へ遷移

### DIFF
--- a/app/views/records/_photo_thumb.html.erb
+++ b/app/views/records/_photo_thumb.html.erb
@@ -1,8 +1,10 @@
 <td>
   <% if record.image.attached? %>
-    <%= image_tag record.image.variant(:thumb),
-                  class: 'thumb',
-                  alt: t('shared.photo_thumb_alt', shop_name: record.ramen_shop.name) %>
+    <%= link_to url_for(record.image), target: '_blank', rel: 'noopener noreferrer' do %>
+      <%= image_tag record.image.variant(:thumb),
+                    class: 'thumb',
+                    alt: t('shared.photo_thumb_alt', shop_name: record.ramen_shop.name) %>
+    <% end %>
   <% else %>
     -
   <% end %>


### PR DESCRIPTION
## Summary

- `records/_photo_thumb` パーシャルのサムネイルをリンクで囲み、クリックでオリジナル画像を別タブで開くように変更

## Test plan

- [ ] 写真付きレコードのサムネイルをクリックするとオリジナル画像が別タブで開く
- [ ] 写真なしレコードは変わらず `-` が表示される