### PR TITLE
refactor: 待ち時間セルをパーシャル化し、全一覧テーブルでリタイアラベルを統一

### DIFF
--- a/app/views/favorite_records/index.html+v2.erb
+++ b/app/views/favorite_records/index.html+v2.erb
@@ -33,7 +33,7 @@
           <% @records.each do |record| %>
             <tr>
               <td><%= link_to record.ramen_shop.name, record.ramen_shop %></td>
-              <td><%= link_to format_wait_time_human(record.wait_time), record_path(record) %></td>
+              <%= render 'records/wait_time_cell', record: record %>
               <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
               <td><%= format_datetime(record.started_at) %></td>
               <%= render 'records/photo_thumb', record: record %>

--- a/app/views/new_records/_records_table.html+v2.erb
+++ b/app/views/new_records/_records_table.html+v2.erb
@@ -16,13 +16,7 @@
         <% records.each do |record| %>
           <tr>
             <td><%= link_to record.ramen_shop.name, record.ramen_shop %></td>
-            <td>
-              <% if record.wait_time %>
-                <%= link_to format_wait_time_human(record.wait_time), record_path(record) %>
-              <% else %>
-                <%= link_to t('new_records.index.connecting'), record_path(record) %>
-              <% end %>
-            </td>
+            <%= render 'records/wait_time_cell', record: record %>
             <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-author"><%= link_to record.user.name, record.user %></td>

--- a/app/views/ramen_shops/show.html+v2.erb
+++ b/app/views/ramen_shops/show.html+v2.erb
@@ -51,10 +51,7 @@
       <tbody>
         <% @records.each do |record| %>
           <tr>
-            <td>
-              <%= link_to format_wait_time_human(record.wait_time), record_path(record, back: 'ramen_shops') %>
-              <%= t('.retired_label') if record.is_retired? %>
-            </td>
+            <%= render 'records/wait_time_cell', record: record, back: 'ramen_shops' %>
             <td class="col-queue"><%= format_line_status(record.line_statuses.first) %></td>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-author"><%= link_to record.user.name, user_path(record.user) %></td>

--- a/app/views/records/_wait_time_cell.html.erb
+++ b/app/views/records/_wait_time_cell.html.erb
@@ -1,0 +1,8 @@
+<td>
+  <% if record.wait_time %>
+    <%= link_to format_wait_time_human(record.wait_time), record_path(record, back: local_assigns[:back]) %>
+    <%= t('shared.retired_label') if record.is_retired? %>
+  <% else %>
+    <%= link_to t('shared.connecting'), record_path(record, back: local_assigns[:back]) %>
+  <% end %>
+</td>

--- a/app/views/users/show.html+v2.erb
+++ b/app/views/users/show.html+v2.erb
@@ -58,7 +58,7 @@
         <% @records.each do |record| %>
           <tr>
             <td><%= link_to record.ramen_shop.name, record.ramen_shop %></td>
-            <td><%= link_to format_wait_time_human(record.wait_time), record_path(record, back: 'user') %></td>
+            <%= render 'records/wait_time_cell', record: record, back: 'user' %>
             <td><%= format_datetime(record.started_at) %></td>
             <td class="col-genre"><%= format_line_status(record.line_statuses.first) %></td>
             <%= render 'records/photo_thumb', record: record %>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -17,7 +17,6 @@ ja:
       datetime_header: "接続日時"
       author_header: "記録者"
       status_header: "接続行列"
-      connecting: "接続中"
       no_records: "記録がありません"
 
   layouts:
@@ -52,6 +51,8 @@ ja:
     breadcrumb_home: "着丼"
     photo_header: "写真"
     photo_thumb_alt: "%{shop_name} の写真"
+    retired_label: "[リタイア]"
+    connecting: "接続中"
     nav:
       active_record: "接続中記録"
       connect: "現在地から接続"
@@ -178,7 +179,6 @@ ja:
       queue_header: "接続行列"
       comment_header: "コメント"
       datetime_header: "接続日時"
-      retired_label: "[リタイア]"
       no_records: "まだ着丼記録がありません"
     near_shops:
       heading: "現在地周辺の店舗"


### PR DESCRIPTION
## Summary

- `records/_wait_time_cell` パーシャルを新規作成し、4つの一覧テーブルの待ち時間セルを集約
- `ramen_shops/show` のみに存在していたリタイアラベル（`[リタイア]`）を全ページに統一
- 接続中（`wait_time: nil`）の表示も一元管理
- `back:` パラメータはオプション（`local_assigns[:back]` で安全に参照）
- `retired_label` / `connecting` 翻訳キーを `shared` に移動

## Test plan

- [ ] `/ramen_shops/:id` — リタイア記録に `[リタイア]` が表示される（既存動作の確認）
- [ ] `/users/:id` — リタイア記録に `[リタイア]` が表示される
- [ ] `/favorite_records` — リタイア記録に `[リタイア]` が表示される
- [ ] `/` 新着記録 — 接続中は「接続中」リンク、リタイア記録は `[リタイア]` が表示される
- [ ] 各ページの待ち時間リンクをクリックすると記録詳細に遷移し、戻るリンクが正しく機能する