### PR TITLE
feat: フォーム投稿ボタンをリクエスト処理中にdisabledにして二重投稿を防止

### DIFF
--- a/app/assets/stylesheets/v2.css
+++ b/app/assets/stylesheets/v2.css
@@ -49,6 +49,11 @@ button, .btn {
   box-sizing: border-box;
 }
 
+button:disabled, .btn:disabled, input[type="submit"]:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* フォーム */
 label { display: block; }
 input[type="checkbox"] + label,

--- a/app/views/line_statuses/_new.html+v2.erb
+++ b/app/views/line_statuses/_new.html+v2.erb
@@ -7,7 +7,7 @@
     <hr>
     <%= form_with model: [@record, @line_status], data: { turbo_stream: true } do |f| %>
       <%= render 'line_statuses/form_fields', f: f %>
-      <p><%= f.submit t('.submit'), class: "btn btn-block" %></p>
+      <p><%= f.submit t('.submit'), class: "btn btn-block", data: { turbo_submits_with: t('.submit_disable_with') } %></p>
     <% end %>
     <a href="#" data-action="click->v2-modal#close"><%= t('.close') %></a>
   </div>

--- a/app/views/password_resets/edit.html+v2.erb
+++ b/app/views/password_resets/edit.html+v2.erb
@@ -17,5 +17,5 @@
     <%= f.label :password_confirmation, t('.password_confirmation_label') %>
     <%= f.password_field :password_confirmation %>
   </p>
-  <p><%= f.submit t('.submit'), class: 'btn btn-block' %></p>
+  <p><%= f.submit t('.submit'), class: 'btn btn-block', data: { turbo_submits_with: t('.submit_disable_with') } %></p>
 <% end %>

--- a/app/views/password_resets/new.html+v2.erb
+++ b/app/views/password_resets/new.html+v2.erb
@@ -13,7 +13,7 @@
     <%= f.label :email, t('.email_label') %>
     <%= f.email_field :email %>
   </p>
-  <p><%= f.submit t('.submit'), class: 'btn btn-block' %></p>
+  <p><%= f.submit t('.submit'), class: 'btn btn-block', data: { turbo_submits_with: t('.submit_disable_with') } %></p>
 <% end %>
 
 <hr>

--- a/app/views/records/_form.html+v2.erb
+++ b/app/views/records/_form.html+v2.erb
@@ -18,6 +18,6 @@
 
   <p>
     <%= f.submit t('.submit'), class: 'btn btn-block',
-          data: { action: "click->record-form#fetchStartAt", disable_with: t('.submit_disable_with') } %>
+          data: { action: "click->record-form#fetchStartAt", turbo_submits_with: t('.submit_disable_with') } %>
   </p>
 <% end %>

--- a/app/views/records/measure.html+v2.erb
+++ b/app/views/records/measure.html+v2.erb
@@ -27,7 +27,7 @@
   <%= form_with model: @record, url: calculate_record_path do |f| %>
     <%= f.hidden_field :ended_at, data: { timer_target: "endedAt" } %>
     <p><%= f.submit t('.submit'),
-          data: { action: "click->timer#end", disable_with: t('.submit_disable_with') },
+          data: { action: "click->timer#end", turbo_submits_with: t('.submit_disable_with') },
           class: "btn btn-block" %></p>
   <% end %>
 

--- a/app/views/records/result.html+v2.erb
+++ b/app/views/records/result.html+v2.erb
@@ -28,7 +28,7 @@
       <%= image_tag '', data: { image_uploader_target: "imagePrev" }, style: 'display:none; max-height: 120px; margin-top: 8px;' %>
     </p>
   </div>
-  <p><%= f.submit t('.submit'), class: "btn btn-block" %></p>
+  <p><%= f.submit t('.submit'), class: "btn btn-block", data: { turbo_submits_with: t('.submit_disable_with') } %></p>
 <% end %>
 
 <hr>

--- a/app/views/sessions/new.html+v2.erb
+++ b/app/views/sessions/new.html+v2.erb
@@ -19,7 +19,7 @@
     <%= f.check_box :remember_me %>
     <%= f.label :remember_me, t('.remember_me') %>
   </p>
-  <p><%= f.submit t('.submit'), class: 'btn btn-block' %></p>
+  <p><%= f.submit t('.submit'), class: 'btn btn-block', data: { turbo_submits_with: t('.submit_disable_with') } %></p>
 <% end %>
 
 <hr>

--- a/app/views/shared/_agreement.html+v2.erb
+++ b/app/views/shared/_agreement.html+v2.erb
@@ -6,4 +6,4 @@
     <%= t('.consent') %>
   </small>
 </p>
-<p><%= f.submit t('.submit'), class: 'btn btn-block' %></p>
+<p><%= f.submit t('.submit'), class: 'btn btn-block', data: { turbo_submits_with: t('.submit_disable_with') } %></p>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -39,6 +39,7 @@ ja:
       password_label: "パスワード"
       remember_me: "ログインしたままにする"
       submit: "ログインする"
+      submit_disable_with: "ログイン中..."
       forgot_password: "パスワードをお忘れの方はこちら"
       sign_up: "アカウントをお持ちでない方はこちら"
 
@@ -65,6 +66,7 @@ ja:
       privacy_policy: "プライバシーポリシー"
       consent: "に同意の上、登録してください。"
       submit: "登録する"
+      submit_disable_with: "登録中..."
 
   password_resets:
     new:
@@ -72,6 +74,7 @@ ja:
       description: "メールアドレスへパスワード再設定用のリンクを送付します。"
       email_label: "メールアドレス"
       submit: "再設定用リンクを申請する"
+      submit_disable_with: "申請中..."
       back_to_login: "ログインへ戻る"
     edit:
       heading: "パスワード再設定"
@@ -79,6 +82,7 @@ ja:
       password_hint: "半角英数字6文字以上"
       password_confirmation_label: "パスワード（確認）"
       submit: "パスワードを再設定する"
+      submit_disable_with: "再設定中..."
 
   records:
     measure:
@@ -103,6 +107,7 @@ ja:
       comment_placeholder: "例: 待望の着丼"
       photo_label: "写真（任意）"
       submit: "投稿する"
+      submit_disable_with: "投稿中..."
       queue_section: "行列状況"
     show:
       heading: "着丼記録"
@@ -140,6 +145,7 @@ ja:
     new:
       heading: "追加報告"
       submit: "報告する"
+      submit_disable_with: "報告中..."
       close: "閉じる"
 
   faqs:


### PR DESCRIPTION
## Summary

- 6つのフォームに `data: { disable_with: }` を追加し、送信中はボタンをdisabledに変更
- 各ページの翻訳キーに `submit_disable_with` を追加

## 対象フォーム

| ページ | ボタン | disabled時のテキスト |
|-------|-------|-------------------|
| 着丼記録投稿（result） | 投稿する | 投稿中... |
| ユーザー登録（agreement） | 登録する | 登録中... |
| ログイン（sessions/new） | ログインする | ログイン中... |
| 行列報告（line_statuses/new） | 報告する | 報告中... |
| パスワード再設定申請（password_resets/new） | 再設定用リンクを申請する | 申請中... |
| パスワード再設定（password_resets/edit） | パスワードを再設定する | 再設定中... |

## Test plan

- [ ] 各フォームで送信ボタンをクリックした直後にボタンがdisabledになる
- [ ] レスポンス受信後にボタンが再び有効になる（バリデーションエラー時など）