### PR TITLE
feat: users#edit を v2 レイアウトに移行

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :use_v2_layout!, only: %i[show favorite_shops new create]
+  before_action :use_v2_layout!, only: %i[show favorite_shops new create edit update]
   before_action :logged_in_user, except: %i[new show create]
   before_action :correct_user, only: %i[edit update favorite_shops]
   before_action :admin_user, only: %i[index destroy update_test_mode]

--- a/app/views/users/edit.html+v2.erb
+++ b/app/views/users/edit.html+v2.erb
@@ -1,0 +1,27 @@
+<% add_breadcrumb t('shared.breadcrumb_home'), root_path %>
+<% add_breadcrumb @user.name, @user %>
+<hr>
+
+<%= render 'shared/nav' %>
+<hr>
+
+<h1><%= t('.heading') %></h1>
+
+<% if @user.errors.any? %>
+  <ul role="alert">
+    <% @user.errors.full_messages.each do |msg| %>
+      <li class="flash-alert"><%= msg %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_with model: @user do |f| %>
+  <p>
+    <%= f.label :name, t('.name_label') %>
+    <%= f.text_field :name %>
+  </p>
+<p><%= f.submit t('.submit'), class: 'btn btn-block' %></p>
+<% end %>
+
+<hr>
+<p><%= link_to t('.password_reset'), new_password_reset_path %></p>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -221,6 +221,11 @@ ja:
       close: "× 閉じる"
 
   users:
+    edit:
+      heading: "プロフィール編集"
+      name_label: "ニックネーム"
+      submit: "更新する"
+      password_reset: "パスワードの再設定はこちら"
     new:
       heading: "ユーザー登録"
       name_label: "ニックネーム"


### PR DESCRIPTION
## Summary

- `UsersController#use_v2_layout!` に `edit` / `update` を追加
- `app/views/users/edit.html+v2.erb` を新規作成
  - ニックネーム編集フォーム（アバターは非対応）
  - バリデーションエラー表示
  - パスワード再設定リンク
- `config/locales/views.ja.yml` に `users.edit` キーを追加

## Test plan

- [ ] v2 Cookie が有効な状態でプロフィール編集ページ (`/users/:id/edit`) を開き、v2 レイアウトで表示されることを確認
- [ ] ニックネームを変更して送信し、`users#show` にリダイレクトされ変更が反映されることを確認
- [ ] バリデーションエラー（名前を空にする等）時に同ページでエラーメッセージが表示されることを確認
- [ ] パスワード再設定リンクが機能することを確認
- [ ] `rspec spec/requests/users_spec.rb` が全件パスすること（30 examples, 0 failures 確認済み）