### PR TITLE
chore(deps): upgrade capybara to 3.40.0 (Rack 3.x compatible)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
+  gem "capybara", "~> 3.40"
   gem "selenium-webdriver", '>= 4.15.0'
   gem 'launchy'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,11 +127,11 @@ GEM
     bullet (8.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    capybara (3.39.2)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -293,7 +293,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    matrix (0.4.2)
+    matrix (0.4.3)
     memoist (0.16.2)
     meta-tags (2.22.3)
       actionpack (>= 6.0.0)
@@ -556,7 +556,7 @@ DEPENDENCIES
   bootstrap
   bootstrap_form
   bullet
-  capybara
+  capybara (~> 3.40)
   dartsass-rails
   debug
   dockerfile-rails (>= 1.6)


### PR DESCRIPTION
## Background

PR #316 (stimulus-rails bump) accidentally pulled in rack 2.2.23 → 3.2.6 as a transitive update, causing CI to fail with:

\`\`\`
NameError: uninitialized constant Rack::Handler
/gems/capybara-3.39.2/lib/capybara/registrations/servers.rb:31
\`\`\`

`Rack::Handler` was removed in Rack 3.x. capybara 3.39.2 still references it in server registration, which crashes the test suite whenever rack 3.x is loaded.

## What this PR does

- Upgrades capybara from **3.39.2 → 3.40.0** using `bundle update --conservative capybara`
- Adds a `~> 3.40` version constraint in the Gemfile to prevent regression
- Only `Gemfile`, `Gemfile.lock` are changed (no application code, no spec support changes)

Transitive changes in `Gemfile.lock`:

| gem | before | after |
|-----|--------|-------|
| capybara | 3.39.2 | 3.40.0 |
| matrix | 0.4.2 | 0.4.3 |

rack, rack-test, selenium-webdriver and all production gems remain unchanged.

## Why this is safe

- capybara 3.40.0 is a drop-in minor version bump — public API is unchanged
- `spec/support/capybara.rb` (custom server host/port + headless Chrome) requires no modification
- `Rack::Handler` references replaced with `rackup` gem equivalents in 3.40.0

## Test results

- `bundle exec rspec`: 521 examples, **0 new failures** introduced by this change
  - 7 pre-existing system spec failures due to `selenium:4444` not running in Docker (same as before this PR, passes in CI)
- `bundle exec rubocop`: 134 files inspected, no offenses detected

## Relation to PR #316

This PR should be merged **before** PR #316 (or any other rack 3.x upgrade) to ensure CI remains green.