### PR TITLE
refactor: v2 ビューのラベル後 <br> タグを除去

### DIFF
--- a/app/views/line_statuses/_form_fields.html+v2.erb
+++ b/app/views/line_statuses/_form_fields.html+v2.erb
@@ -1,7 +1,7 @@
 <div data-controller="line-status">
   <div>
     <strong><%= t('.shop_label') %></strong><br>
-    <small><%= t('.shop_hint') %></small><br>
+    <small><%= t('.shop_hint') %></small>
     <div data-action="change->line-status#updateNumberInput">
       <label><%= f.radio_button :line_type, :outside_the_store,
                   checked: f.object.outside_the_store? || f.object.line_type.nil? %> <%= t('.outside') %></label>
@@ -11,7 +11,7 @@
   </div>
   <div data-line-status-target="lineNumberField">
     <p>
-      <label><strong><%= t('.queue_label') %></strong></label><br>
+      <label><strong><%= t('.queue_label') %></strong></label>
       <small><%= t('.queue_hint') %></small><br>
       <%= f.number_field :line_number, inputmode: "numeric", pattern: '\d*', min: 0, max: 999,
             placeholder: t('.queue_placeholder'), style: 'width: 120px;',
@@ -20,7 +20,7 @@
     </p>
   </div>
   <p>
-    <label><strong><%= t('.comment_label') %></strong></label><br>
+    <label><strong><%= t('.comment_label') %></strong></label>
     <%= f.text_area :comment, placeholder: t('.comment_placeholder') %>
   </p>
 </div>

--- a/app/views/line_statuses/_new.html+v2.erb
+++ b/app/views/line_statuses/_new.html+v2.erb
@@ -2,7 +2,7 @@
   <div class="overlay active" data-action="click->v2-modal#close"></div>
   <div class="modal" style="display:block;">
     <p>
-      <strong><%= t('.heading') %></strong> &mdash; <%= @record.ramen_shop.name %><br>
+      <strong><%= t('.heading') %></strong> &mdash; <%= @record.ramen_shop.name %>
     </p>
     <hr>
     <%= form_with model: [@record, @line_status], data: { turbo_stream: true } do |f| %>

--- a/app/views/records/result.html+v2.erb
+++ b/app/views/records/result.html+v2.erb
@@ -17,12 +17,12 @@
 
 <%= form_with model: @record do |f| %>
   <p>
-    <label for="record_comment"><%= t('.comment_label') %></label><br>
+    <label for="record_comment"><%= t('.comment_label') %></label>
     <%= f.text_area :comment, placeholder: t('.comment_placeholder') %>
   </p>
   <div data-controller="image-uploader">
     <p>
-      <label for="record_image"><%= t('.photo_label') %></label><br>
+      <label for="record_image"><%= t('.photo_label') %></label>
       <%= f.file_field :image, accept: "image/jpeg,image/jpg,image/png", direct_upload: true,
             data: { action: "change->image-uploader#displayAfterCheck", image_uploader_target: "image" } %>
       <%= image_tag '', data: { image_uploader_target: "imagePrev" }, style: 'display:none; max-height: 120px; margin-top: 8px;' %>


### PR DESCRIPTION
## Summary

フォームラベル・`<strong>`・`<small>` 要素の直後にある不要な `<br>` タグを削除。CSS で余白を制御する方針に統一。

**対象ファイル:**
- `app/views/line_statuses/_form_fields.html+v2.erb` — 接続先・待ち行列数・コメントの各ラベル後
- `app/views/line_statuses/_new.html+v2.erb` — モーダル見出し後
- `app/views/records/result.html+v2.erb` — コメント・写真ラベル後

## Test plan

- [ ] records#result で着丼フォームのラベル表示が崩れていないことを確認
- [ ] records#measure の追加報告モーダルが正常に表示されることを確認
- [ ] records#new の接続フォームフィールドが正常に表示されることを確認