### PR TITLE
feat: V1/V2 UI 切り替えリンクを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,6 +69,11 @@ module ApplicationHelper
   end
 
   # rubocop:disable Rails/HelperInstanceVariable
+  def toggle_ui_path(enable_v2:)
+    query = request.query_parameters.except('v2').merge('v2' => enable_v2 ? '1' : '0')
+    "#{request.path}?#{query.to_query}"
+  end
+
   def show_connect_button?
     defined?(@show_connect_button) ? @show_connect_button : true
   end

--- a/app/views/layouts/_common_links.html.erb
+++ b/app/views/layouts/_common_links.html.erb
@@ -28,3 +28,8 @@
     お知らせ
   <% end %>
 </li>
+<li>
+  <%= link_to toggle_ui_path(enable_v2: true), class: 'nav-link' do %>
+    新UIへ切り替え
+  <% end %>
+</li>

--- a/app/views/shared/_nav.html+v2.erb
+++ b/app/views/shared/_nav.html+v2.erb
@@ -13,4 +13,5 @@
     | <%= link_to t('.sign_up'), new_user_path %>
     | <%= link_to t('.login'), login_path %>
   <% end %>
+  | <%= link_to t('.switch_to_v1'), toggle_ui_path(enable_v2: false) %>
 </p>

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -62,6 +62,7 @@ ja:
       favorite_records: "お気に入り店舗"
       sign_up: "ユーザー登録"
       login: "ログイン"
+      switch_to_v1: "旧UIへ切り替え"
     agreement:
       terms: "利用規約"
       privacy_policy: "プライバシーポリシー"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe ApplicationHelper do
     end
 
     it 'v2=1 を付与したパスを返す' do
-      expect(helper.toggle_ui_path(enable_v2: true)).to eq('/ramen_shops?v2=1')
+      expect(helper.toggle_ui_path(enable_v2: true)).to eq('/ramen_shops?v2=1') # rubocop:disable Naming/VariableNumber
     end
 
     it 'v2=0 を付与したパスを返す' do
-      expect(helper.toggle_ui_path(enable_v2: false)).to eq('/ramen_shops?v2=0')
+      expect(helper.toggle_ui_path(enable_v2: false)).to eq('/ramen_shops?v2=0') # rubocop:disable Naming/VariableNumber
     end
 
-    context '既存クエリパラメータがある場合' do
+    context 'when existing query parameters are present' do
       before do
         allow(helper.request).to receive_messages(
           path: '/ramen_shops',
@@ -23,10 +23,10 @@ RSpec.describe ApplicationHelper do
       end
 
       it '既存パラメータを保持しつつ v2 を上書きする' do
-        result = helper.toggle_ui_path(enable_v2: false)
+        result = helper.toggle_ui_path(enable_v2: false) # rubocop:disable Naming/VariableNumber
         expect(result).to include('v2=0')
         expect(result).to include('q=')
-        expect(result).not_to include('v2=1')
+        expect(result).to_not include('v2=1')
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#toggle_ui_path' do
+    before do
+      allow(helper.request).to receive_messages(path: '/ramen_shops', query_parameters: {})
+    end
+
+    it 'v2=1 を付与したパスを返す' do
+      expect(helper.toggle_ui_path(enable_v2: true)).to eq('/ramen_shops?v2=1')
+    end
+
+    it 'v2=0 を付与したパスを返す' do
+      expect(helper.toggle_ui_path(enable_v2: false)).to eq('/ramen_shops?v2=0')
+    end
+
+    context '既存クエリパラメータがある場合' do
+      before do
+        allow(helper.request).to receive_messages(
+          path: '/ramen_shops',
+          query_parameters: { 'q' => 'ラーメン', 'v2' => '1' }
+        )
+      end
+
+      it '既存パラメータを保持しつつ v2 を上書きする' do
+        result = helper.toggle_ui_path(enable_v2: false)
+        expect(result).to include('v2=0')
+        expect(result).to include('q=')
+        expect(result).not_to include('v2=1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- 新UI (v2) のナビゲーション末尾に「旧UIへ切り替え」リンクを追加
- 旧UI (v1) のハンバーガーメニュー末尾に「新UIへ切り替え」リンクを追加
- `toggle_ui_path(enable_v2:)` ヘルパーで現在のパスと既存クエリパラメータを保持しつつ `v2` パラメータだけを差し替え

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `app/helpers/application_helper.rb` | `toggle_ui_path` ヘルパーを追加 |
| `app/views/shared/_nav.html+v2.erb` | 「旧UIへ切り替え」リンクを追加 |
| `app/views/layouts/_common_links.html.erb` | 「新UIへ切り替え」リンクを追加 |
| `config/locales/views.ja.yml` | `shared.nav.switch_to_v1` キーを追加 |
| `spec/helpers/application_helper_spec.rb` | `toggle_ui_path` のテストを追加（新規） |

## Test plan

- [ ] `bundle exec rspec spec/helpers/application_helper_spec.rb` が 3 examples, 0 failures で通ること
- [ ] 新UIページのナビゲーションに「旧UIへ切り替え」が表示されること
- [ ] 「旧UIへ切り替え」をクリックすると v2 クッキーが削除されて旧UIに戻ること
- [ ] 旧UIのハンバーガーメニューに「新UIへ切り替え」が表示されること
- [ ] 「新UIへ切り替え」をクリックすると v2 クッキーがセットされて新UIに切り替わること
- [ ] 検索ページなどクエリパラメータがある状態で切り替えても既存パラメータが保持されること