### PR TITLE
feat: ready-for-agent のチケットを消化する自律ループ (Ralph) を導入する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git worktree:*)",
+      "Bash(git fetch:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git restore:*)",
+      "Bash(git push:*)",
+      "Bash(git -C:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh label:*)",
+      "Bash(gh api:*)",
+      "Bash(gh run:*)",
+      "Bash(docker compose:*)",
+      "Bash(ln -s:*)",
+      "Bash(mkdir:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(bundle exec rspec:*)",
+      "Bash(bundle exec rubocop:*)",
+      "Bash(scripts/ralph-once.sh:*)",
+      "Bash(scripts/ralph.sh:*)"
+    ],
+    "deny": [
+      "Bash(gh pr merge:*)",
+      "Bash(gh issue close:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin HEAD:main:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@
 # グローバル gitignore が docs/ を無視している環境でも新規ファイルを拾えるようにする。
 !/docs/
 
+# 同上。グローバル gitignore が ralph-once.sh を無視している環境がある。
+!/scripts/ralph-once.sh
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,18 @@
-## Project Overview
+## tyakudon (ちゃくどん)
 
-**プロジェクト名:** tyakudon (ちゃくどん)
+このファイルは、このリポジトリで**どう働くか**だけを持つ。サービスが何であるか、どんな用語を使うか、なぜその設計になっているかは別のファイルにある。
 
-**概要:** ラーメン店の待ち時間を記録・共有するWebアプリケーション。ユーザーは店舗の待ち時間を投稿し、他のユーザーと共有できます。OpenAI を活用した応援メッセージ機能も提供しています。
+| 知りたいこと | 読む場所 |
+| --- | --- |
+| サービスの説明とドメイン語彙（接続 / 着丼 / 着丼記録 / お気に入り店舗 など） | [`CONTEXT.md`](./CONTEXT.md) |
+| 設計判断の記録と、その理由 | [`docs/adr/`](./docs/adr/) |
+| v2 UI 移行の方針・命名規則・実装パターン | [`docs/v2_ui_migration.md`](./docs/v2_ui_migration.md) |
+| Issue / PRD の扱い（GitHub Issues + `gh` CLI） | [`docs/agents/issue-tracker.md`](./docs/agents/issue-tracker.md) |
+| triage ラベルの対応表 | [`docs/agents/triage-labels.md`](./docs/agents/triage-labels.md) |
+| ドメインドキュメントの読み方（single-context 構成） | [`docs/agents/domain.md`](./docs/agents/domain.md) |
+| 自律ループ (Ralph) の回し方 | [`docs/agents/loop.md`](./docs/agents/loop.md) |
+
+ドメイン概念を名指しするとき（issue のタイトル、テスト名、UI のラベル、コミットメッセージ）は `CONTEXT.md` の用語をそのまま使う。用語集が `_Avoid_` に挙げた言い換えを持ち込まない。
 
 **技術スタック:**
 
@@ -12,15 +22,6 @@
 - Hotwire (Turbo + Stimulus)
 - Docker Compose (開発環境)
 - Fly.io (本番環境)
-
-**主要機能:**
-
-- 待ち時間記録の投稿・閲覧
-- 店舗情報の管理（Geocoder による位置情報）
-- いいね・お気に入り機能
-- OpenAI による応援メッセージ生成
-- Google OAuth2 認証
-- Webスクレイピングによる店舗データ自動取得
 
 ## Critical Rules
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo is **single-context**: one `CONTEXT.md` and one `docs/adr/` at the root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-....md
+│   └── 0002-....md
+└── app/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in [`moriw0/tyakudon`](https://github.com/moriw0/tyakudon). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/moriw0/tyakudon/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/moriw0/tyakudon/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/loop.md
+++ b/docs/agents/loop.md
@@ -1,0 +1,76 @@
+# 自律ループ (Ralph)
+
+`ready-for-agent` のチケットを、エージェントが 1 件ずつ実装して PR にするループ。[Ralph Wiggum の技法](https://www.aihero.dev/getting-started-with-ralph)を、このリポジトリの制約に合わせて変形したもの。
+
+## 回し方
+
+```
+scripts/ralph-once.sh          1 回だけ。キューから 1 件、エージェントが選ぶ
+scripts/ralph-once.sh 337      1 回だけ。#337 を指定
+scripts/ralph.sh 5             上限 5 回の AFK ループ
+```
+
+反復上限は必須。既定値はない。キューが空になるとエージェントが `<promise>QUEUE_EMPTY</promise>` を出力し、そこで即終了する。終了時に macOS の通知が出る。
+
+モデルは `RALPH_MODEL` で上書きできる。`ralph-once.sh` の既定は Opus、`ralph.sh` の既定は Sonnet。once で Opus を使うのは、品質が低かったときに「プロンプトが悪いのか、モデルが足りないのか」を切り分けられるようにするため。
+
+```
+RALPH_MODEL=sonnet scripts/ralph-once.sh 337
+```
+
+## 1 イテレーションの中身
+
+手順の本体は [`scripts/ralph-prompt.md`](../../scripts/ralph-prompt.md) にある。スクリプトはそれを毎回そのまま `claude -p` に渡すだけ。
+
+1. キューを引く（open / `ready-for-agent` / `blocked_by == 0` / assignee なし）
+2. 1 件選ぶ — **どれをやるかはエージェントが判断する**
+3. `gh issue edit --add-assignee @me` で claim
+4. `.claude/worktrees/issue-<n>/` に worktree を作る
+5. `implement` スキルの手順で実装（内部で `tdd`）
+6. フルスイート + RuboCop
+7. `code-review` スキル。CRITICAL / HIGH かつ範囲内なら直して 6 に戻る
+8. PR を出す（`Closes #<n>`）
+9. worktree を削除
+
+## 翌朝、何を見るか
+
+```
+gh pr list
+gh issue list --label ready-for-human
+```
+
+- **通常の PR** — レビューしてマージする。マージが依存の解決を兼ねるので、`blocked_by` が減って次のイテレーションのキューが広がる
+- **draft PR** — エージェントが詰まったもの。PR 本文と issue コメントに「どこで詰まったか」「何を判断してほしいか」が書いてある。続きをやるか、閉じるかを決める
+- **`ready-for-human` ラベル** — 打ち切られたチケット。ループはもう掴まない
+
+ログは `tmp/ralph/<timestamp>-iter<n>.log`（gitignore 済み）。成功時の記録は PR に集約してあるので、ログを開くのは何かおかしいときだけでいい。
+
+## ループが止まるとき
+
+3 つある。どれも異常ではない。
+
+- **キューが空** — 全部終わったか、残りが全部 blocked / `ready-for-human` になった。どちらかは最終出力に書いてある
+- **反復上限に到達** — もう一度回せばいい
+- **異常終了** — スクリプトが exit code を返して止まる。ログを見る
+
+依存が未解決のチケットは、blocker の PR をマージするまでキューに現れない。**マージしないとキューが枯れる**のは設計どおりで、レビューが追いつかないまま PR が積み上がるのを防いでいる。
+
+## Ralph からの変形点
+
+原型は PRD.md と progress.txt でタスクを管理し、エージェントに仕様の分解から実装まで丸ごと任せる。このリポジトリでは 3 点を変えた。
+
+**状態は GitHub issues に一本化した。** チケット、依存関係、完了判定がすでに GitHub 側にある。progress.txt を足すと二重管理になる。「前回の判断」は git log と PR から読む。
+
+**成果物は PR で、マージは人間。** `main` は保護されていて（必須チェック `RuboCop` / `Rspec`、force push 禁止、`enforce_admins`）、そもそも直接コミットできない。結果として、依存の解決とレビューが同じイベントになった。
+
+**仕様の分解はループの外に置いた。** 塊 → チケットへの分解にはこのリポジトリの判断が濃く入っていて、そこが品質の源泉になっている。実際 #334 では「導線ゼロ」の誤判定が起票段階で 1 件混入し、人間の推敲で捕まっている。ここを自動化すると、誤った前提のまま複数の PR が出る。ループは分解の**下流**だけを担う。
+
+したがって、ある塊のチケットを消化しきるとループは止まる。次の塊のチケットは人間が起こす（`to-tickets` / `to-spec` / `grill-with-docs` などのスキルが使える）。起こしたら同じスクリプトをまた回すだけ。
+
+## 環境の前提
+
+- **worktree の symlink は相対パスで作る。** compose の mount が `.:/rails` なので、ホストの絶対パスはコンテナ内で解決できない
+- **`.ENV` と `config/master.key`** は gitignore されていて worktree に存在しない。symlink で通す
+- **`app/assets/builds/application.css`** も gitignore。worktree では `bin/rails dartsass:build` が要る。これがないとレイアウトを描画する spec が `Sprockets::Rails::Helper::AssetNotFound` で落ちる
+- **テスト DB はリポジトリ全体で 1 つ。** worktree を分けても並列には回せない。実行は直列
+- **権限は `.claude/settings.json` の allow / deny リスト**で制御する。`--dangerously-skip-permissions` は使わない。deny リストで `gh pr merge` / `gh issue close` / `main` への push / force push を機械的に塞いでいる

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,25 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Label existence
+
+All five labels exist in this repo. `gh label list` shows what's currently defined.
+
+## How the loop uses them
+
+`ready-for-agent` means "an AFK agent can complete this ticket on its own" — it is the queue the autonomous loop reads (see `loop.md`). It belongs on implementation tickets only, never on tracking or spec issues.
+
+The loop moves a ticket to `ready-for-human` when it gives up on it, and files anything it finds outside a ticket's scope as a new issue labelled `needs-triage`. It never applies `needs-info` or `wontfix` — those are yours.

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Ralph ループを 1 回だけ回す。プロンプトを育てる段階と、初回の様子見に使う。
+#
+#   scripts/ralph-once.sh          キューから 1 件、エージェントが選ぶ
+#   scripts/ralph-once.sh 337      #337 を指定して回す
+#
+# モデルは RALPH_MODEL で上書きできる (既定: opus)。
+# 初回に opus を使うのは、品質が低かったときに「プロンプトが悪いのか
+# モデルが足りないのか」を切り分けられるようにするため。
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+MODEL="${RALPH_MODEL:-opus}"
+ISSUE="${1:-}"
+
+mkdir -p tmp/ralph
+LOG="tmp/ralph/$(date +%Y%m%d-%H%M%S)-once.log"
+
+PROMPT="$(cat scripts/ralph-prompt.md)"
+
+if [ -n "$ISSUE" ]; then
+  PROMPT="${PROMPT}
+
+---
+
+## このイテレーションの指定
+
+キューから選ぶ手順 (1 と 2) は飛ばし、**#${ISSUE} を実装してください**。
+#${ISSUE} が open で assignee がおらず blocked_by が 0 であることだけ確認し、
+そうでなければ理由を出力して何もせず終了してください。"
+fi
+
+git worktree prune
+
+echo "=== ralph-once (model: ${MODEL}${ISSUE:+, issue: #$ISSUE}) ==="
+echo "=== log: ${LOG} ==="
+
+claude --permission-mode acceptEdits --model "$MODEL" -p "$PROMPT" 2>&1 | tee "$LOG"

--- a/scripts/ralph-prompt.md
+++ b/scripts/ralph-prompt.md
@@ -1,0 +1,183 @@
+# Ralph ループ: 1 イテレーションの手順
+
+あなたは AFK エージェントです。このプロンプトは毎回まっさらなコンテキストで渡されます。前回のイテレーションの記憶はありません。状態は GitHub issues と git にしかないので、必要な情報はそこから読み直してください。
+
+**1 回の実行で、チケットを 1 件だけ片付けます。** 複数のチケットにまたがってはいけません。
+
+## 0. 前提を読む
+
+- `CLAUDE.md` — このリポジトリでの働き方
+- `CONTEXT.md` — ドメイン語彙。issue のタイトル、テスト名、UI のラベル、コミットメッセージで概念を名指しするときは、ここの用語をそのまま使う。`_Avoid_` に挙がった言い換えを持ち込まない
+- `docs/adr/` — 設計判断。作業する領域に関わるものを読む
+- `docs/v2_ui_migration.md` — v2 UI 移行の方針・命名規則・実装パターン
+
+## 1. キューを引く
+
+キューの定義は次の 4 条件をすべて満たす issue です。
+
+- open である
+- `ready-for-agent` ラベルが付いている
+- `blocked_by == 0`（GitHub ネイティブの issue dependencies で判定する。本文の散文ではない）
+- assignee がいない
+
+```
+gh issue list --label ready-for-agent --state open --json number,title \
+  --jq '.[] | .number' \
+| while read -r n; do
+    gh api "repos/{owner}/{repo}/issues/$n" \
+      --jq 'select(.issue_dependencies_summary.blocked_by == 0)
+            | select((.assignees | length) == 0)
+            | "\(.number)\t\(.title)"'
+  done
+```
+
+**キューが空なら、他に何もせず `<promise>QUEUE_EMPTY</promise>` とだけ出力して終了してください。** 「全部終わった」場合と「残りが全部 blocked か `ready-for-human` になった」場合を区別する必要はありません。どちらも「いま自動で進められる仕事がない」であり、停止が正しい。ただし最終出力の 1 段落で、どちらなのかは書いてください。
+
+## 2. チケットを 1 件選ぶ
+
+**優先順位はあなたが判断します。** 番号順や依存の数といった機械的な規則は与えません。キューに残ったチケットの本文を読み、いま着手すべき 1 件を自分で決めてください。判断の根拠は最終出力に 1 行で書くこと。
+
+選んだら、そのチケットと親 issue（本文の `## Parent` にある）を `gh issue view <n> --comments` で読み、受け入れ条件を把握します。
+
+## 3. claim する
+
+```
+gh issue edit <n> --add-assignee @me
+```
+
+これがこのイテレーション最初の書き込みです。以降で詰まっても、assignee は外しません（次のイテレーションが同じチケットを掴まないため）。
+
+## 4. worktree を用意する
+
+ブランチ名は `<type>/<issue番号>-<slug>` の形にします（例: `fix/337-v2-layout-leak`）。type は Conventional Commits の語彙から選びます。
+
+```
+N=<issue番号>
+BR=<ブランチ名>
+WT=.claude/worktrees/issue-$N
+
+git fetch origin
+git worktree add "$WT" -b "$BR" origin/main
+```
+
+続いて下ごしらえをします。`.ENV` と `config/master.key` は gitignore されているため worktree に存在せず、これがないと Rails が起動しません。
+
+**symlink は必ず相対パスにしてください。** compose の mount が `.:/rails` なので、ホストの絶対パスはコンテナ内で解決できません。
+
+```
+ln -s ../../../.ENV "$WT/.ENV"
+ln -s ../../../../config/master.key "$WT/config/master.key"
+```
+
+さらに、ビルド済み CSS（`app/assets/builds/application.css`）も gitignore されているため worktree にありません。これがないとレイアウトを描画する spec が `Sprockets::Rails::Helper::AssetNotFound` で落ちます。
+
+```
+docker compose exec -w "/rails/$WT" app bin/rails dartsass:build
+```
+
+以降の作業はすべて `$WT` の中で行います。リポジトリ本体の作業ツリーには一切触れないでください。
+
+## 5. 実装する
+
+`~/.claude/skills/implement/SKILL.md` を読み、その手順に従って実装してください。このスキルはモデルから自動起動できない設定になっているため、ファイルを読んで内容に従う形を取ります。
+
+- テストを先に書ける箇所では `tdd` スキルを使う
+- 単体の spec はこまめに、フルスイートは最後に 1 回
+- コミットは Conventional Commits（`fix:` / `refactor:` / `test:` / `docs:` / `feat:`）
+
+## 6. 検証する
+
+```
+docker compose exec -w "/rails/$WT" app bundle exec rspec
+docker compose exec -w "/rails/$WT" app bundle exec rubocop
+```
+
+**フルスイートが緑で、RuboCop に新規の違反がないこと。** どちらかが落ちている状態で PR を出してはいけません。
+
+テスト DB はリポジトリ全体で 1 つしかありません。並列で回さないでください。
+
+## 7. レビューする
+
+`code-review` スキルを使います。Standards 軸（このリポジトリの規約準拠）と Spec 軸（元 issue の受け入れ条件との一致）の 2 本が走ります。
+
+- **CRITICAL / HIGH で、かつチケットの範囲内**の指摘 → 直して 6 に戻る
+- **MEDIUM 以下**の指摘 → 直さない。PR 本文の「レビュー所見」に列挙する
+- **CRITICAL / HIGH でも、チケットの範囲外**の指摘（例: このコントローラー全体が太い）→ 直さない。PR 本文に書き、必要なら 禁止事項 5 に従って新規 issue を立てる
+
+## 8. PR を出す
+
+```
+git -C "$WT" push -u origin "$BR"
+```
+
+PR 本文は `generate-pr-body` スキルに従って組み立てます。必ず含めるもの:
+
+- `Closes #<issue番号>`
+- レビュー所見（7 で直さなかったもの。なければ「なし」と書く）
+- 範囲外で気づいたこと（起票した issue へのリンクを含む）
+
+## 9. 後片付け
+
+```
+git worktree remove "$WT"
+```
+
+worktree を残したまま終了しないでください。次のイテレーションのノイズになります。
+
+---
+
+## 詰まったときの出口
+
+次のいずれかに当たったら、そのチケットは**そこで打ち切ります**。粘らないでください。
+
+1. フルスイートを緑にする試行が **3 回**失敗した
+2. 受け入れ条件に、コードを読んでも判断できない曖昧さがある
+3. チケットに書かれている前提が崩れていることを見つけた（例: 「導線ゼロ」とされたコードに実は導線があった）
+
+打ち切るときの手順:
+
+1. そこまでの作業をコミットして push する
+2. **draft** PR を作る（`gh pr create --draft`）。本文に「どこで詰まったか」「何を確認したか」「人間に何を判断してほしいか」を書く
+3. `gh issue comment <n>` で同じ内容を要約して残す
+4. `gh issue edit <n> --remove-label ready-for-agent --add-label ready-for-human`
+5. worktree を削除する
+
+ラベルの付け替えを忘れないでください。これを忘れると、次のイテレーションが同じチケットを掴んで同じ場所で詰まります。
+
+打ち切ってもループは止まりません。次のイテレーションが別のチケットを取ります。
+
+---
+
+## 禁止事項
+
+**絶対にしないこと**
+
+1. `main` への直接 push、PR のマージ、issue のクローズ。issue は PR がマージされたときに `Closes #<n>` で閉じる
+2. チケットに列挙されていないファイルの削除。ADR-0001 が「廃止機能のコードとデータは温存する」と決めているため、削除してよいのはチケットが明示的に列挙したものだけ
+3. `Gemfile` / `Gemfile.lock` / `db/schema.rb` / マイグレーション / `.github/workflows/` / `compose.yaml` の変更
+4. テストを通すためにテストを緩めること。ただし**チケットが名指ししている spec ファイルの書き換えは作業対象**（system spec の v2 化などは、その書き換え自体がチケットの中身）
+5. リポジトリ本体の作業ツリーでの作業。すべて worktree の中で行う
+
+**やらずに記録すること**
+
+6. チケットの範囲外で見つけた問題は直さない。`gh issue create --label needs-triage` で新規 issue を立て、PR 本文からリンクする
+7. `CONTEXT.md` / `docs/adr/` / `docs/v2_ui_migration.md` は変更しない。矛盾を見つけたら issue コメントに書く。これらは「変わらない情報」として置かれており、黙って書き換えると設計判断の履歴が壊れる
+8. 追跡 issue（#332 など）のチェックボックスは触らない。マージ時に人間が更新する
+
+**必ず守ること**
+
+9. 1 イテレーション = 1 チケット = 1 PR
+10. コミットメッセージと PR 本文で、ドメイン概念は `CONTEXT.md` の用語をそのまま使う
+
+---
+
+## 最終出力
+
+作業が終わったら、次を 1 段落ずつで報告してください。
+
+- 選んだチケットと、それを選んだ理由
+- やったこと
+- PR の URL（draft ならその旨）
+- 次のイテレーションに引き継ぐ注意点があれば
+
+キューが空だった場合は `<promise>QUEUE_EMPTY</promise>` を出力したうえで、空になった理由（全完了か、残りが blocked / `ready-for-human` か）を 1 段落で書いてください。

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Ralph ループを AFK で回す。1 イテレーション = 1 チケット = 1 PR。
+#
+#   scripts/ralph.sh 5
+#
+# 反復上限は必須。既定値は設けない。
+# キューが空になるとエージェントが <promise>QUEUE_EMPTY</promise> を出力し、
+# そこで即終了する。
+#
+# モデルは RALPH_MODEL で上書きできる (既定: sonnet)。
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <max-iterations>" >&2
+  exit 1
+fi
+
+MAX="$1"
+MODEL="${RALPH_MODEL:-sonnet}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p tmp/ralph
+
+notify() {
+  osascript -e "display notification \"$1\" with title \"Ralph\"" 2>/dev/null || true
+  echo "=== $1 ==="
+}
+
+PROMPT="$(cat scripts/ralph-prompt.md)"
+
+for ((i = 1; i <= MAX; i++)); do
+  LOG="tmp/ralph/${STAMP}-iter${i}.log"
+
+  echo "=== iteration ${i}/${MAX} (model: ${MODEL}) ==="
+  echo "=== log: ${LOG} ==="
+
+  # 前のイテレーションが途中で死んで worktree を残していても、ここで掃除される
+  git worktree prune
+
+  set +e
+  claude --permission-mode acceptEdits --model "$MODEL" -p "$PROMPT" 2>&1 | tee "$LOG"
+  STATUS="${PIPESTATUS[0]}"
+  set -e
+
+  if [ "$STATUS" -ne 0 ]; then
+    notify "イテレーション ${i} が異常終了しました (exit ${STATUS})"
+    exit "$STATUS"
+  fi
+
+  if grep -q "<promise>QUEUE_EMPTY</promise>" "$LOG"; then
+    notify "キューが空になりました (${i} 回で終了)"
+    exit 0
+  fi
+done
+
+notify "反復上限 ${MAX} 回に到達しました"


### PR DESCRIPTION
## Summary

v2 移行の塊1 は #335-#343 として `ready-for-agent` のチケットに分解済みで、各チケットに受け入れ条件と GitHub ネイティブの issue dependencies が入っている。この形のタスクを 1 件ずつ人手で回すのは時間がかかるので、[Ralph Wiggum の技法](https://www.aihero.dev/getting-started-with-ralph)（毎回まっさらなコンテキストで同じプロンプトを回す）を持ち込み、チケットを 1 件ずつ実装して PR にするループを入れる。

あわせて、ループが読む土台を整理した。`CLAUDE.md` が `CONTEXT.md` と重複していて、しかも先に腐っていた。

- 「主要機能」に `OpenAI による応援メッセージ生成` を掲げているが、ADR-0001 と #339 でこれから止める
- 「いいね・**お気に入り**機能」という書き方が、`CONTEXT.md` が「UI 上のラベルで必ず区別する」と定めた**お気に入り店舗**と**お気に入り店舗の記録**を潰している。用語集の `_Avoid_` に違反している記述が、エージェントが最初に読むファイルに載っていた

機能一覧を 2 箇所に持たない構造にして、同じ腐り方が再発しないようにする。

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `scripts/ralph-prompt.md` | 新規。毎回そのまま `claude -p` に渡すプロンプト本体。キューの定義 / 9 ステップの手順 / 禁止事項 10 件 / 詰まったときの出口 / 完了サイジル |
| `scripts/ralph-once.sh` | 新規。1 回だけ回す。引数で issue 番号を指定できる。既定モデルは Opus |
| `scripts/ralph.sh` | 新規。上限 n 回の AFK ループ。`<promise>QUEUE_EMPTY</promise>` で早期終了。既定モデルは Sonnet |
| `docs/agents/loop.md` | 新規。回し方、翌朝の見方、Ralph からの変形点、環境の前提 |
| `.claude/settings.json` | 新規。ループが必要とする権限の allow リストと、禁止事項を機械的に塞ぐ deny リスト |
| `CLAUDE.md` | 「概要」「主要機能」を削除し、冒頭を各ドキュメントへの索引に置換。`CLAUDE.local.md` の Agent skills 節を移入 |
| `docs/agents/{domain,issue-tracker,triage-labels}.md` | untracked だった 3 ファイルを追跡下に入れる。`triage-labels.md` はラベルの実在状況を実態に合わせ、ループがどのラベルをどう使うかを追記 |
| `.gitignore` | `!/scripts/ralph-once.sh` を追加 |

`CLAUDE.local.md` は削除した（内容は `CLAUDE.md` に移動）。

## 補足

### 差分に現れないリポジトリ側の変更

- ラベル `needs-triage` / `needs-info` / `ready-for-human` を作成した（`docs/agents/triage-labels.md` の 5 ロールのうち未作成だった 3 件）
- #334 から `ready-for-agent` を外した。塊1 の詳細仕様であって作業チケットではないため。付けたままだとキューに現れ、エージェントが 1 イテレーションで 9 チケット分を丸ごとやろうとする

### Ralph からの変形点

原型は `PRD.md` と `progress.txt` でタスクを管理し、仕様の分解から実装まで丸ごとエージェントに任せる。3 点を変えた。

**状態は GitHub issues に一本化した。** チケット・依存関係・完了判定がすでに GitHub 側にある。`progress.txt` を足すと二重管理になり、issue のクローズとズレたときにどちらが正か決められない。「前回の判断」は git log と PR から読む。

**成果物は PR で、マージは人間。** `main` は保護されていて（必須チェック `RuboCop` / `Rspec`、force push 禁止、`enforce_admins`）そもそも直接コミットできない。結果として依存の解決とレビューが同じイベントになった。**マージしないとキューが枯れて止まる**のは設計どおりで、レビューが追いつかないまま PR が積み上がるのを防ぐ throttle として機能する。いまの依存だと、マージなしで流せるのは #335-#339 の 5 件まで。

**仕様の分解はループの外に置いた。** 塊 → チケットへの分解には判断が濃く入っていて、そこが品質の源泉になっている。実際 #334 では `records#update` を「導線ゼロのデッドコード」と誤判定していたのが推敲で捕まっている。ここを自動化すると誤った前提のまま複数の PR が出る。ある塊を消化しきるとループは止まり、次の塊のチケットは人間が起こす。

### 権限は deny リストで機械的に塞ぐ

`--dangerously-skip-permissions` は使わず、`--permission-mode acceptEdits` + allow リストで回す。加えて deny リストで `gh pr merge` / `gh issue close` / `main` への push / force push を塞いだ。プロンプトの禁止事項に散文で書くだけにしない。

### `.gitignore` に `!/scripts/ralph-once.sh` を追加した理由

#333 の `!/docs/` と同じ問題。グローバル gitignore (`~/.gitignore_global:21`) が `ralph-once.sh` を無視していて、1 度目のコミットからこのファイルだけが黙って落ちていた。リポジトリ側で打ち消す。

### `CLAUDE.local.md` を追跡下に移した理由

中身は `docs/agents/*.md` への索引 3 件のみで秘密情報はない。一方、ループは将来別のマシンや clean clone でも回りうるので、issue tracker の作法が gitignore されたファイルにしかない状態は壊れやすい。

### worktree まわりで先回りして潰した落とし穴

- **symlink は相対パスでないと動かない。** compose の mount が `.:/rails` なので、ホストの絶対パス (`/Users/shota/...`) はコンテナ内で解決できない
- **worktree では `bin/rails dartsass:build` が要る。** `app/assets/builds/application.css` は gitignore されていて worktree に存在せず、無いとレイアウトを描画する spec が `Sprockets::Rails::Helper::AssetNotFound` で落ちる
- **テスト DB はリポジトリ全体で 1 つ。** worktree を分けても並列には回せないので、実行は直列

## Test plan

コード変更はなく、Rails アプリの挙動には影響しない。ループ自体の動作確認は、マージ後に `scripts/ralph-once.sh` を 1 回走らせて行う（worktree は `origin/main` から切られるため、この PR がマージされるまでループは新しい `CLAUDE.md` も `.claude/settings.json` も読めない）。

- [x] プロンプトに書いたキュークエリが #335-#339 の 5 件だけを返し、#334 が除外されること
- [x] `bash -n scripts/ralph.sh` / `bash -n scripts/ralph-once.sh` が通ること
- [x] `git check-ignore scripts/ralph-once.sh` が ignore しないこと
- [ ] `scripts/ralph-once.sh 337` が worktree を作り、`.ENV` と `config/master.key` の symlink がコンテナ内で解決すること
- [ ] worktree 内で `dartsass:build` 後にフルスイートが緑になること（system spec を含む）
- [ ] headless で権限プロンプトが出ないこと（allow リストの穴の洗い出し）
- [ ] `~/.claude/hooks/rubocop-precommit.sh` が headless でループを止めないこと
- [ ] `tdd` / `code-review` スキルが headless で起動すること
- [ ] イテレーション終了時に worktree が残っていないこと
- [ ] `scripts/ralph.sh 5` が 6 回目を待たずに `QUEUE_EMPTY` で終了すること
