### PR TITLE
fix: 初回実行で分かった 2 点を自律ループに反映する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,9 @@
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
       "Bash(git push origin main:*)",
-      "Bash(git push origin HEAD:main:*)"
+      "Bash(git push origin HEAD:main:*)",
+      "Bash(docker compose up:*)",
+      "Bash(docker compose down:*)"
     ]
   }
 }

--- a/docs/agents/loop.md
+++ b/docs/agents/loop.md
@@ -73,4 +73,5 @@ gh issue list --label ready-for-human
 - **`.ENV` と `config/master.key`** は gitignore されていて worktree に存在しない。symlink で通す
 - **`app/assets/builds/application.css`** も gitignore。worktree では `bin/rails dartsass:build` が要る。これがないとレイアウトを描画する spec が `Sprockets::Rails::Helper::AssetNotFound` で落ちる
 - **テスト DB はリポジトリ全体で 1 つ。** worktree を分けても並列には回せない。実行は直列
+- **`docker compose` は必ずリポジトリ本体のディレクトリから打つ。** プロジェクト名がカレントディレクトリ名から決まるため、worktree の中から `docker compose up` を打つと `issue-337` のような別プロジェクトが立ち上がり、空の DB volume を持つ二重のスタックができる。初回の実行で実際に起きたので、`up` / `down` は deny リストで塞いである
 - **権限は `.claude/settings.json` の allow / deny リスト**で制御する。`--dangerously-skip-permissions` は使わない。deny リストで `gh pr merge` / `gh issue close` / `main` への push / force push を機械的に塞いでいる

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -38,4 +38,5 @@ git worktree prune
 echo "=== ralph-once (model: ${MODEL}${ISSUE:+, issue: #$ISSUE}) ==="
 echo "=== log: ${LOG} ==="
 
-claude --permission-mode acceptEdits --model "$MODEL" -p "$PROMPT" 2>&1 | tee "$LOG"
+# --verbose なしだと出力が完了時まで一括バッファされ、途中経過が見えない
+claude --permission-mode acceptEdits --model "$MODEL" --verbose -p "$PROMPT" 2>&1 | tee "$LOG"

--- a/scripts/ralph-prompt.md
+++ b/scripts/ralph-prompt.md
@@ -75,7 +75,15 @@ ln -s ../../../../config/master.key "$WT/config/master.key"
 docker compose exec -w "/rails/$WT" app bin/rails dartsass:build
 ```
 
-以降の作業はすべて `$WT` の中で行います。リポジトリ本体の作業ツリーには一切触れないでください。
+以降の**ファイルの変更**はすべて `$WT` の中で行います。リポジトリ本体の作業ツリーには一切触れないでください。
+
+ただし `docker compose` だけは別です。**必ずリポジトリ本体のディレクトリから打ってください。** compose のプロジェクト名はカレントディレクトリ名から決まるため、worktree の中から `docker compose up` を打つと `issue-337` という別プロジェクトが立ち上がり、空の DB volume を持つ二重のスタックができます（初回の実行で実際に起きました）。
+
+コンテナに対して打ってよいのは、本体のディレクトリからの `exec` だけです。
+
+```
+docker compose exec -w "/rails/$WT" app <コマンド>
+```
 
 ## 5. 実装する
 
@@ -102,7 +110,7 @@ docker compose exec -w "/rails/$WT" app bundle exec rubocop
 
 - **CRITICAL / HIGH で、かつチケットの範囲内**の指摘 → 直して 6 に戻る
 - **MEDIUM 以下**の指摘 → 直さない。PR 本文の「レビュー所見」に列挙する
-- **CRITICAL / HIGH でも、チケットの範囲外**の指摘（例: このコントローラー全体が太い）→ 直さない。PR 本文に書き、必要なら 禁止事項 5 に従って新規 issue を立てる
+- **CRITICAL / HIGH でも、チケットの範囲外**の指摘（例: このコントローラー全体が太い）→ 直さない。PR 本文に書き、必要なら 禁止事項 7 に従って新規 issue を立てる
 
 ## 8. PR を出す
 
@@ -156,18 +164,19 @@ worktree を残したまま終了しないでください。次のイテレー�
 2. チケットに列挙されていないファイルの削除。ADR-0001 が「廃止機能のコードとデータは温存する」と決めているため、削除してよいのはチケットが明示的に列挙したものだけ
 3. `Gemfile` / `Gemfile.lock` / `db/schema.rb` / マイグレーション / `.github/workflows/` / `compose.yaml` の変更
 4. テストを通すためにテストを緩めること。ただし**チケットが名指ししている spec ファイルの書き換えは作業対象**（system spec の v2 化などは、その書き換え自体がチケットの中身）
-5. リポジトリ本体の作業ツリーでの作業。すべて worktree の中で行う
+5. リポジトリ本体の作業ツリーでのファイル変更。すべて worktree の中で行う
+6. `docker compose up` / `docker compose down`。コンテナはすでに起動している。触ってよいのは本体のディレクトリからの `docker compose exec -w "/rails/$WT" app ...` だけ
 
 **やらずに記録すること**
 
-6. チケットの範囲外で見つけた問題は直さない。`gh issue create --label needs-triage` で新規 issue を立て、PR 本文からリンクする
-7. `CONTEXT.md` / `docs/adr/` / `docs/v2_ui_migration.md` は変更しない。矛盾を見つけたら issue コメントに書く。これらは「変わらない情報」として置かれており、黙って書き換えると設計判断の履歴が壊れる
-8. 追跡 issue（#332 など）のチェックボックスは触らない。マージ時に人間が更新する
+7. チケットの範囲外で見つけた問題は直さない。`gh issue create --label needs-triage` で新規 issue を立て、PR 本文からリンクする
+8. `CONTEXT.md` / `docs/adr/` / `docs/v2_ui_migration.md` は変更しない。矛盾を見つけたら issue コメントに書く。これらは「変わらない情報」として置かれており、黙って書き換えると設計判断の履歴が壊れる
+9. 追跡 issue（#332 など）のチェックボックスは触らない。マージ時に人間が更新する
 
 **必ず守ること**
 
-9. 1 イテレーション = 1 チケット = 1 PR
-10. コミットメッセージと PR 本文で、ドメイン概念は `CONTEXT.md` の用語をそのまま使う
+10. 1 イテレーション = 1 チケット = 1 PR
+11. コミットメッセージと PR 本文で、ドメイン概念は `CONTEXT.md` の用語をそのまま使う
 
 ---
 

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -42,7 +42,8 @@ for ((i = 1; i <= MAX; i++)); do
   git worktree prune
 
   set +e
-  claude --permission-mode acceptEdits --model "$MODEL" -p "$PROMPT" 2>&1 | tee "$LOG"
+  # --verbose なしだと出力が完了時まで一括バッファされ、途中経過が見えない
+  claude --permission-mode acceptEdits --model "$MODEL" --verbose -p "$PROMPT" 2>&1 | tee "$LOG"
   STATUS="${PIPESTATUS[0]}"
   set -e
 


### PR DESCRIPTION
## Summary

#344 で入れた自律ループを `scripts/ralph-once.sh 337` で 1 回走らせ、そこで分かった 2 点を反映する。実行自体は完走し、#346 が出た（所要 約 14 分、フルスイート 532 examples 0 failures）。

### 途中経過が見えない

プレーンな `-p` は出力を完了時まで一括バッファする。14 分間 `tmp/ralph/*.log` が 0 バイトのままで、外から `git worktree list` と `gh pr list` を叩いて進行を推測するしかなかった。HITL の初回として見えなさすぎるので `--verbose` を足す。

### worktree から `docker compose` を打つと別スタックが立つ

エージェントが worktree をカレントディレクトリにしたまま `docker compose up -d` を打ち、`issue-337` という別の compose プロジェクトを作った。compose のプロジェクト名はカレントディレクトリ名から決まるため、`compose.yaml` が同じでも**空の DB volume を持つ二重のスタック**ができる。ポート 3000 の衝突で気づいて `docker compose down -v` で撤去され、本体の `tyakudon-*` コンテナは無傷だった（`docker compose ls -a` と `docker volume ls` で残骸ゼロを確認済み）。

散文で禁止するだけでなく、deny リストでも塞ぐ。ループがコンテナに対して打ってよいのは本体のディレクトリからの `docker compose exec -w "/rails/$WT" app ...` だけ。

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `scripts/ralph-once.sh` / `scripts/ralph.sh` | `claude` の起動に `--verbose` を追加 |
| `scripts/ralph-prompt.md` | worktree 作成の節に compose プロジェクト名の罠を明記。禁止事項に `docker compose up` / `down` を追加し、以降の番号と本文中の相互参照を振り直し |
| `.claude/settings.json` | deny リストに `docker compose up` / `docker compose down` を追加 |
| `docs/agents/loop.md` | 「環境の前提」に同じ内容を追記 |

## 補足

### 初回実行で潰れた検証項目

#344 の Test plan のうち、今回の実行で確認できたもの。

- 相対 symlink (`.ENV` / `config/master.key`) がコンテナ内で解決した
- worktree で `dartsass:build` 後にフルスイートが緑になった（532 examples 0 failures）
- headless で権限プロンプトによる停止は起きなかった。allow リストに穴はなかった
- `rubocop-precommit.sh` フックはループを止めなかった
- `tdd` / `code-review` スキルはどちらも起動した。`code-review` の Spec 軸が HIGH 2 件を拾い、同じイテレーション内で修正された
- イテレーション終了時に worktree は残っていなかった

未検証で残るのは `scripts/ralph.sh <n>` の複数回ループと `QUEUE_EMPTY` での早期終了。

### 設計どおりに動いた部分

- **範囲外の発見を直さず起票した** — #345 (`disable_connect_button` が v2 のナビに効いていない) を `needs-triage` で起票し、PR 本文からリンクした。`docs/v2_ui_migration.md` の記述と実装が食い違うが、doc が古いのか実装漏れか判断できないため doc は書き換えていない。禁止事項 7・8 のとおり
- **CRITICAL / HIGH を同じイテレーションで直した** — `records/result.html+v2.erb` と `password_resets/edit.html+v2.erb` がエラーを描画していないため、opt-in を足すだけだと「v1 に戻る」が「何が悪かったか分からない」に置き換わる、という退行を Spec 軸が指摘した。MEDIUM 以下 4 件は直さず PR 本文に列挙されている
- **チケットの範囲に収まった** — #346 の差分は +82/-3、8 ファイル。`only:` への最小追加とエラー描画のみ

## Test plan

ループの設定とプロンプトのみの変更で、Rails アプリの挙動には影響しない。

- [x] `bash -n scripts/ralph.sh` / `bash -n scripts/ralph-once.sh` が通ること
- [x] `.claude/settings.json` が JSON として妥当で、deny が 8 件になっていること
- [x] `scripts/ralph-prompt.md` の禁止事項の番号と、本文中の相互参照が一致していること
- [ ] `--verbose` 付きで `tmp/ralph/*.log` に途中経過が逐次書かれること
- [ ] worktree から `docker compose up` を打とうとすると deny されること
- [ ] `scripts/ralph.sh 4` が残りのチケットを消化し、`QUEUE_EMPTY` で終了すること
