### PR TITLE
fix: ループの出力を stream-json にして途中経過が見えるようにする

### DIFF
--- a/docs/agents/loop.md
+++ b/docs/agents/loop.md
@@ -43,7 +43,15 @@ gh issue list --label ready-for-human
 - **draft PR** — エージェントが詰まったもの。PR 本文と issue コメントに「どこで詰まったか」「何を判断してほしいか」が書いてある。続きをやるか、閉じるかを決める
 - **`ready-for-human` ラベル** — 打ち切られたチケット。ループはもう掴まない
 
-ログは `tmp/ralph/<timestamp>-iter<n>.log`（gitignore 済み）。成功時の記録は PR に集約してあるので、ログを開くのは何かおかしいときだけでいい。
+ログは `tmp/ralph/<timestamp>-iter<n>.log`（gitignore 済み）。`--output-format stream-json` の**生の JSONL** が入っている。人が読むときは digest を通す。
+
+```
+scripts/ralph-digest.sh < tmp/ralph/20260726-171516-iter2.log
+```
+
+コンソールには実行中も同じ digest が流れる（`claude | tee "$LOG" | scripts/ralph-digest.sh`）。テキスト出力モードは完了時まで一括バッファされ、`--verbose` を足しても変わらないため、進行を見るには stream-json が必要。
+
+成功時の記録は PR に集約してあるので、ログを開くのは何かおかしいときだけでいい。生の JSONL には各ツール呼び出しの入出力が全部入っているので、詰まった箇所を追うときは `jq` で掘れる。
 
 ## ループが止まるとき
 

--- a/scripts/ralph-digest.sh
+++ b/scripts/ralph-digest.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# claude --output-format stream-json の JSONL を、人が読める 1 行に落として流す。
+# 標準入力から読み、標準出力に書く。ログは呼び出し側が tee で生のまま残す。
+#
+#   claude ... --output-format stream-json --verbose -p "$PROMPT" 2>&1 \
+#     | tee "$LOG" | scripts/ralph-digest.sh
+#
+# JSON として読めない行 (stderr が混ざったものなど) は素通しする。
+# jq がない環境では全部素通しする。
+
+set -uo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  cat
+  exit 0
+fi
+
+exec jq -rR --unbuffered '
+  . as $line
+  | (fromjson? // null) as $e
+  | if $e == null then
+      $line
+    elif $e.type == "assistant" then
+      $e.message.content[]?
+      | if .type == "text" then
+          (.text | gsub("\\s+"; " ")) as $t
+          | $t | select(length > 0)
+        elif .type == "tool_use" then
+          ((.input.command // .input.file_path // .input.pattern // .input.prompt // "")
+            | tostring | gsub("\\s+"; " ")) as $arg
+          | "-> \(.name): \($arg[0:140])"
+        else empty end
+    elif $e.type == "user" then
+      $e.message.content[]?
+      | select(.type == "tool_result" and (.is_error == true))
+      | ((.content | tostring) | gsub("\\s+"; " ")) as $c
+      | "   ! \($c[0:200])"
+    elif $e.type == "result" then
+      "--- \($e.subtype): \($e.num_turns) turns / \(($e.duration_api_ms / 1000) | floor)s ---"
+    else empty end
+'

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -38,5 +38,9 @@ git worktree prune
 echo "=== ralph-once (model: ${MODEL}${ISSUE:+, issue: #$ISSUE}) ==="
 echo "=== log: ${LOG} ==="
 
-# --verbose なしだと出力が完了時まで一括バッファされ、途中経過が見えない
-claude --permission-mode acceptEdits --model "$MODEL" --verbose -p "$PROMPT" 2>&1 | tee "$LOG"
+# テキスト出力は完了時まで一括バッファされる。--verbose を足しても変わらない。
+# stream-json はイベント発生順に届くので、生の JSONL を LOG に残しつつ、
+# コンソールには digest を流す。
+claude --permission-mode acceptEdits --model "$MODEL" \
+  --output-format stream-json --verbose -p "$PROMPT" 2>&1 \
+  | tee "$LOG" | scripts/ralph-digest.sh

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -42,8 +42,12 @@ for ((i = 1; i <= MAX; i++)); do
   git worktree prune
 
   set +e
-  # --verbose なしだと出力が完了時まで一括バッファされ、途中経過が見えない
-  claude --permission-mode acceptEdits --model "$MODEL" --verbose -p "$PROMPT" 2>&1 | tee "$LOG"
+  # テキスト出力は完了時まで一括バッファされる。--verbose を足しても変わらない。
+  # stream-json はイベント発生順に届くので、生の JSONL を LOG に残しつつ、
+  # コンソールには digest を流す。
+  claude --permission-mode acceptEdits --model "$MODEL" \
+    --output-format stream-json --verbose -p "$PROMPT" 2>&1 \
+    | tee "$LOG" | scripts/ralph-digest.sh
   STATUS="${PIPESTATUS[0]}"
   set -e
 


### PR DESCRIPTION
## Summary

#347 で「途中経過が見えない」問題に `--verbose` を足したが、直っていなかった。#350 のイテレーション（約 10 分）でログの最初の 1 バイトが書かれたのは終了時刻の 17:25:04 で、その内容は最終報告の文章だった。**テキスト出力モードは完了時まで一括バッファされ、`--verbose` を足しても変わらない。**

`--output-format stream-json` はイベント発生順に届く。実測（同じ 4 ツールのプロンプト、`claude | tee | digest` の本番と同じパイプライン形）:

```
=== start 21:14:19 ===
21:14:22 | 4回のツールを順番に実行します。
21:14:23 | -> Bash: ls
21:14:26 | Rails プロジェクトの標準的なディレクトリ構成が確認できました。次に直近のコミット履歴を見ます。
21:14:26 | -> Bash: git log --oneline -3
21:14:30 | -> Bash: wc -l CONTEXT.md
21:14:34 | -> Bash: docker compose ps --format "{{.Service}}"
21:14:39 | --- success: 5 turns / 18s ---
=== end 21:14:40 ===
```

生の JSONL をログに残し、コンソールには digest を流す。JSONL をそのまま画面に出すと読めないため。

## digest の設計

`scripts/ralph-digest.sh` は標準入力の JSONL を 1 行に落とす。拾うのは 3 種類だけ。

- アシスタントの発話
- ツール呼び出し（`-> Bash: <コマンド>` の形。`command` / `file_path` / `pattern` / `prompt` のいずれかを 140 文字で切る）
- `is_error` が立った `tool_result`（`! <内容>` を 200 文字で切る）

`rate_limit_event` や `system` は落とす。**JSON として読めない行は素通しする。** `2>&1` で混ざる stderr を jq が食って死ぬと、SIGPIPE が `tee` 経由で `claude` まで伝わってイテレーションを巻き込むため。`jq` がない環境では `cat` にフォールバックする。

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `scripts/ralph-digest.sh` | 新規。JSONL → 人が読める 1 行 |
| `scripts/ralph.sh` / `scripts/ralph-once.sh` | `--verbose` を `--output-format stream-json --verbose` に変え、`tee "$LOG" \| scripts/ralph-digest.sh` を通す |
| `docs/agents/loop.md` | ログが JSONL になったこと、`scripts/ralph-digest.sh < <log>` で後から読めることを追記 |

## Test plan

ループの出力経路のみの変更で、Rails アプリの挙動には影響しない。

- [x] `bash -n` が 3 本すべて通ること
- [x] `stream-json` の各行が発生時点で届くこと（行ごとのタイムスタンプで確認、上記）
- [x] `claude \| tee \| digest` のパイプライン形でも遅延しないこと（上記）
- [x] digest が実際の JSONL（13 行のサンプル）から発話・ツール呼び出し・完了行を出すこと
- [x] JSON でない行を素通しすること
- [x] `is_error` の `tool_result` を `!` 付きで出すこと
- [x] `scripts/ralph-digest.sh` がグローバル gitignore に捕まっていないこと
- [x] ログが JSONL になっても `ralph.sh` の 2 つの grep が効くこと（`<promise>QUEUE_EMPTY</promise>` と PR URL のガード。JSON 内の `\n` エスケープを挟んでも一致する）
- [ ] 実際のイテレーションで digest が流れること（次に `scripts/ralph.sh` を回したときに確認）

## 補足

マージ後の main でフルスイートを流して緑を確認済み（519 examples, 0 failures, 1 pending）。#349 と #350 はどちらも削除を含む PR で、CI はそれぞれ別のベースで緑になっただけだったため、合流後を一度見ている。例数が 532 → 519 に減っているのは #350 が `line_statuses` と `records#edit` の request spec を消したぶん。
