### PR TITLE
fix: v2ナビの お気に入り店舗の記録 を お気に入り店舗 と区別できる文言にする

### DIFF
--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -21,9 +21,6 @@ ja:
 
   layouts:
     v2:
-      nav:
-        active_record: "接続中記録"
-        connect: "現在地から接続"
       footer: "着丼 - ラーメン待ち時間記録システム"
       footer_announcements: "お知らせ"
       footer_faqs: "FAQ"
@@ -59,7 +56,7 @@ ja:
       connect: "現在地から接続"
       home: "新着記録"
       search: "店舗検索"
-      favorite_records: "お気に入り店舗"
+      favorite_records: "お気に入り店舗の記録"
       sign_up: "ユーザー登録"
       login: "ログイン"
       switch_to_v1: "旧UIへ切り替え"

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe 'Records' do
         expect(response.body).to include ramen_shop_path(record.ramen_shop)
       end
     end
+
+    context 'when logged in with v2_ui cookie' do
+      before do
+        log_in_as(user)
+        cookies[:v2_ui] = '1'
+      end
+
+      it 'labels the favorite_records nav link distinctly from favorite shops' do
+        do_request
+        expect(response.body).to include 'お気に入り店舗の記録'
+      end
+    end
   end
 
   describe 'GET /ramen_shops/:ramen_shop_id/records/new #new' do


### PR DESCRIPTION
## Summary

Closes #335

v2 のナビにある お気に入り店舗 へのリンクは、実際には お気に入り店舗の記録 の一覧に着く。プロフィールからたどれる お気に入り店舗（店舗そのものの一覧、`users#favorite_shops`）と同じラベルだったため、押すまでどちらに着くのか分からなかった。CONTEXT.md で別語として定義されている 2 つを、UI 上で区別できる文言にした。

あわせて、ロケールに `layouts.v2.nav` と `shared.nav` の 2 つの `nav` があり、前者は `active_record` と `connect` だけを持つ参照されない重複だったため削除した（実際のナビ (`shared/_nav.html+v2.erb`) は lazy lookup で `shared.nav.*` を参照しており、`layouts.v2.nav.*` はどこからも呼ばれていなかった）。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `config/locales/views.ja.yml` | `shared.nav.favorite_records` の値を `"お気に入り店舗"` → `"お気に入り店舗の記録"` に変更。ロケールキー自体は変えていない。未参照だった `layouts.v2.nav`（`active_record` / `connect`）を削除 |
| `spec/requests/records_spec.rb` | `GET /records/:id #show` に、ログイン済み + `v2_ui` cookie でナビの新ラベルが出ることを固定する example を追加 |

## レビュー所見

`code-review` スキルの Standards 軸 / Spec 軸を回した。どちらも CRITICAL / HIGH の指摘なし。なし。

## 範囲外で気づいたこと

なし。

## Test plan

- [x] `docker compose exec app bundle exec rspec` が緑（520 examples, 0 failures, 1 pending）
- [x] `docker compose exec app bundle exec rubocop` で変更ファイルに新規違反なし（既存 117 offenses は本変更と無関係なファイルのもの）
- [x] v2 でログイン済みユーザーがページを開くと、ナビに「お気に入り店舗の記録」が表示される
- [x] `layouts.v2.nav` への参照がリポジトリ全体からゼロであることを確認済み
- [x] ロケールキー `favorite_records` は変更していない
