### PR TITLE
fix: 停止判定をエージェントの最終報告だけに限定する

### DIFF
--- a/docs/agents/loop.md
+++ b/docs/agents/loop.md
@@ -83,4 +83,6 @@ scripts/ralph-digest.sh < tmp/ralph/20260726-171516-iter2.log
 - **テスト DB はリポジトリ全体で 1 つ。** worktree を分けても並列には回せない。実行は直列
 - **`docker compose` は必ずリポジトリ本体のディレクトリから打つ。** プロジェクト名がカレントディレクトリ名から決まるため、worktree の中から `docker compose up` を打つと `issue-337` のような別プロジェクトが立ち上がり、空の DB volume を持つ二重のスタックができる。初回の実行で実際に起きたので、`up` / `down` は deny リストで塞いである
 - **権限は `.claude/settings.json` の allow / deny リスト**で制御する。`--dangerously-skip-permissions` は使わない。deny リストで `gh pr merge` / `gh issue close` / `main` への push / force push を機械的に塞いでいる
+- **停止判定はエージェントの最終報告だけを見る。** `stream-json` のログにはツールの出力が丸ごと入るので、ログ全体を grep すると `gh pr view` や `git log` が拾ってきた文章で誤判定する。実際 PR #351 の本文に書いた `<promise>QUEUE_EMPTY</promise>` という引用がログに入り、キューが残っているのに「空」と判定して止まった。判定材料は `result` イベントの `.result` に限る
+- **1 イテレーションあたり 10 件前後の権限拒否は正常。** `result` イベントの `permission_denials` に件数が出る（実測 12 件）。エージェントは弾かれた形を自分で言い換えて先へ進むので、ターンを数回損するだけで止まりはしない。プロンプトで先回りできるものは書いてあるが、ゼロにはならない
 - **複合コマンドは allow リストで通らない。** パイプやループを含むコマンドは個々のパターンに分解して照合できないため、構成要素がすべて allow でも承認要求になる。headless では答える相手がいないので、エージェントは何もせず終了する（`scripts/ralph.sh` の初回でキュー取得がこれに当たり、1 イテレーションが数秒で空振りした）。定型のパイプラインはスクリプトに切り出して、そのスクリプト自体を allow する（`scripts/ralph-queue.sh` がその例）

--- a/scripts/ralph-prompt.md
+++ b/scripts/ralph-prompt.md
@@ -66,6 +66,8 @@ ln -s ../../../.ENV "$WT/.ENV"
 ln -s ../../../../config/master.key "$WT/config/master.key"
 ```
 
+**張れたかどうかを `ls` / `stat` / Read で確かめないでください。** ハーネスがシークレットの読み取りを機械的に拒否するため、必ず失敗します。symlink が張れていないときは後段の `dartsass:build` か rspec が落ちるので、そこで気づけば十分です。
+
 さらに、ビルド済み CSS（`app/assets/builds/application.css`）も gitignore されているため worktree にありません。これがないとレイアウトを描画する spec が `Sprockets::Rails::Helper::AssetNotFound` で落ちます。
 
 ```
@@ -73,6 +75,8 @@ docker compose exec -w "/rails/$WT" app bin/rails dartsass:build
 ```
 
 以降の**ファイルの変更**はすべて `$WT` の中で行います。リポジトリ本体の作業ツリーには一切触れないでください。
+
+**worktree に対する git は必ず `git -C "$WT" <サブコマンド>` の形で打ってください。** `cd "$WT" && git ...` は、対象ディレクトリの hook が走りうるためハーネスが拒否します。`status` / `diff` / `add` / `commit` / `push` / `show` すべて同じです。
 
 ただし `docker compose` だけは別です。**必ずリポジトリ本体のディレクトリから打ってください。** compose のプロジェクト名はカレントディレクトリ名から決まるため、worktree の中から `docker compose up` を打つと `issue-337` という別プロジェクトが立ち上がり、空の DB volume を持つ二重のスタックができます（初回の実行で実際に起きました）。
 
@@ -120,6 +124,14 @@ PR 本文は `generate-pr-body` スキルに従って組み立てます。必ず
 - `Closes #<issue番号>`
 - レビュー所見（7 で直さなかったもの。なければ「なし」と書く）
 - 範囲外で気づいたこと（起票した issue へのリンクを含む）
+
+**本文は `$WT/tmp/pr-body.md` に書き出して `--body-file` で渡してください。**
+
+```
+gh pr create --title "<タイトル>" --head "$BR" --body-file "$WT/tmp/pr-body.md"
+```
+
+`--body` に長文を直接渡すとコマンド置換や引用符でハーネスに拒否されます。`/tmp` などプロジェクト外には書けません。`tmp/` は gitignore 済みなのでコミットには入りません。
 
 ## 9. 後片付け
 

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -56,7 +56,22 @@ for ((i = 1; i <= MAX; i++)); do
     exit "$STATUS"
   fi
 
-  if grep -q "<promise>QUEUE_EMPTY</promise>" "$LOG"; then
+  # 判定はエージェントの最終報告 (result イベントの .result) だけを見る。
+  # ログ全体を見てはいけない。stream-json にはツールの出力が丸ごと入るので、
+  # gh pr view や git log が拾ってきた文章に紛れた文字列で誤判定する。
+  # 実際、PR #351 の本文に書いた <promise>QUEUE_EMPTY</promise> という
+  # 引用がログに入り、キューが残っているのに空と判定して止まった。
+  if command -v jq >/dev/null 2>&1; then
+    FINAL="$(jq -r 'select(.type == "result") | .result // empty' "$LOG" 2>/dev/null)"
+    DENIALS="$(jq -r 'select(.type == "result") | (.permission_denials | length)' "$LOG" 2>/dev/null)"
+    [ -n "${DENIALS:-}" ] && echo "=== 権限で弾かれたツール呼び出し: ${DENIALS} 件 ==="
+  else
+    # jq がなければ判定材料はログ全体しかない。誤判定しうるが、
+    # 毎回止まるよりはましなので従来どおりにする。
+    FINAL="$(cat "$LOG")"
+  fi
+
+  if printf '%s' "$FINAL" | grep -q "<promise>QUEUE_EMPTY</promise>"; then
     notify "キューが空になりました (${i} 回で終了)"
     exit 0
   fi
@@ -66,7 +81,9 @@ for ((i = 1; i <= MAX; i++)); do
   # 空振りしている。承認待ちで止まった場合が代表例で、claude は exit 0 を
   # 返すため exit code では検知できない。放置すると残りの回数を
   # 黙って空振りし続けるので、ここで止める。
-  if ! grep -qE 'https://github\.com/[^ ]+/pull/[0-9]+' "$LOG"; then
+  # 最終報告そのものが取れなかった場合 (result イベントがない = 途中で
+  # 死んだ) も、ここで引っかかって止まる。
+  if ! printf '%s' "$FINAL" | grep -qE 'https://github\.com/[^ ]+/pull/[0-9]+'; then
     notify "イテレーション ${i} が PR を出さずに終了しました。ログを確認してください"
     exit 1
   fi


### PR DESCRIPTION
## Summary

`scripts/ralph.sh 3` を回したところ、#335 の PR (#352) を出したあとイテレーション 1 でループが止まり、「キューが空になりました (1 回で終了)」と報告した。キューには #336 が残っていた。

原因は #351 で入れた `stream-json` との相互作用。**ログにツールの出力が丸ごと入るようになったため、ログ全体を grep する停止判定が、エージェントの宣言ではない文字列に一致した。**

一致したのは #351 の本文に書いた Test plan の一文だった。

> - [x] ログが JSONL になっても `ralph.sh` の 2 つの grep が効くこと（`<promise>QUEUE_EMPTY</promise>` と PR URL のガード…）

エージェントが `gh pr view` か `git log` でこの文章を拾い、それがログに入った。「grep が効くことを確認した」と書いた行が grep を誤爆させたことになる。#351 の検証は合成 JSONL で行ったので、実際のツール出力が混ざる状況を再現できていなかった。

## 直し方

判定材料を `result` イベントの `.result`（エージェントの最終報告そのもの）に限定する。ツールの出力はここに入らない。

```
FINAL="$(jq -r 'select(.type == "result") | .result // empty' "$LOG")"
```

`result` イベントが取れない場合（途中で死んだ場合）は `FINAL` が空になり、PR URL のガードに引っかかって停止する。`jq` がない環境ではログ全体にフォールバックする（誤判定しうるが、毎回止まるよりはまし）。

あわせて `permission_denials` の件数をイテレーションごとに出すようにした。今回の実測は **12 件**。

## プロンプト側で潰した無駄

digest が流れるようになったおかげで、実行中に見えた摩擦を 3 つ拾えた。いずれもエージェントは自力で言い換えて回復していて、止まってはいない。損はターン数だけ。

| 弾かれた形 | 書いた指示 |
|---|---|
| `cd "$WT" && git ...`（対象ディレクトリの hook が走りうる） | worktree への git は最初から `git -C "$WT"` |
| 長文の `--body`、`/tmp/pr-body.md` への書き出し | 本文は `$WT/tmp/pr-body.md` に書いて `--body-file` |
| `ls` / `stat` / Read での `.ENV` `master.key` の存在確認 | 読み取りで確かめない。張れていなければ後段で落ちる |

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `scripts/ralph.sh` | 停止判定を `.result` に限定。`permission_denials` の件数を表示 |
| `scripts/ralph-prompt.md` | 上表の 3 点を追記 |
| `docs/agents/loop.md` | 「環境の前提」に判定の原則と、権限拒否が常時 10 件前後出ることを追記 |

## Test plan

- [x] `bash -n scripts/ralph.sh` が通ること
- [x] 実際のイテレーションのログ（`20260727-074906-iter1.log`）で `QUEUE_EMPTY` を誤検知しないこと
- [x] 同じログで PR URL を検知すること
- [x] `.result` に `QUEUE_EMPTY` を含む合成ログで検知すること（真陽性）
- [x] ログ本文にだけ PR URL がある合成ログで、PR URL を検知しないこと
- [ ] 実際のループで #336 を消化し、次のイテレーションで `QUEUE_EMPTY` で止まること

## 補足: allow リストに 1 行足すか

エージェントは終了コードを拾うために `; echo "---EXIT:$?---"` を後置する癖があり、`echo` が allow にないため複合コマンドごと弾かれる（1 イテレーションで 2〜3 ターンの損）。`.claude/settings.json` に `"Bash(echo:*)"` を足せば消えるが、**この変更は auto mode の classifier に拒否された**（エージェントに権限設定を書き換えさせない保護）。妥当な保護なので回避していない。入れるかどうかは人間の判断。
