### PR TITLE
fix: v2 レイアウトに ActionText の CSS を通す

### DIFF
--- a/app/views/layouts/v2.html.erb
+++ b/app/views/layouts/v2.html.erb
@@ -6,6 +6,7 @@
   <title><%= content_for?(:title) ? yield(:title) : "着丼" %></title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <%= stylesheet_link_tag "actiontext" %>
   <%= stylesheet_link_tag "v2", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>

--- a/spec/requests/announcements_spec.rb
+++ b/spec/requests/announcements_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe '/announcements' do
         get announcement_path(announcement)
         expect(response).to be_successful
       end
+
+      it 'loads the ActionText stylesheet in the v2 layout' do
+        cookies[:v2_ui] = '1'
+        get announcement_path(announcement)
+        expect(response.body).to match(/<link[^>]*actiontext[^"]*\.css/)
+      end
     end
 
     context 'with a draft announcement' do


### PR DESCRIPTION
## Summary

Closes #336

v2 のお知らせ詳細が無スタイルで出ていた。本文がベタ組みになり、見出しも引用も箇条書きも効いていない。ActionText のスタイルシートが v1 レイアウトからしか読まれておらず、v2 レイアウトは `trix-content` のスタイルを持っていなかったため。

v2 レイアウトから ActionText のスタイルシートを読むようにした。塊3 で管理者向けの Trix エディタを v2 化するときも同じスタイルが必要になるため、v2 側に取り込む形にしてある。

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `app/views/layouts/v2.html.erb` | `stylesheet_link_tag "actiontext"` を追加 |
| `spec/requests/announcements_spec.rb` | v2 レイアウトが ActionText のスタイルシートへの link を含むことを固定する request spec を追加 |

v1 レイアウト（`application.html.erb`）は変更していない。すでに ActionText のスタイルシートを読んでいるため見た目は変わらない。

## レビュー所見

`code-review` スキルの Standards 軸 / Spec 軸を回した。CRITICAL / HIGH の指摘なし。

- Standards 軸: `docs/v2_ui_migration.md` の設計方針表は CSS フレームワークを「なし（`v2.css` のみ）」としており、字面だけ見ると今回の追加と衝突しうる。ただしこの行はフレームワーク選択（Bootstrap を使うか）についての記述であり、ActionText 用の CSS を否定するものではないと判断し、そのまま採用（judgement call）。
- Standards 軸: 「v2 レイアウトがアセット X を読んでいる」を確認するテストの書き方（`cookies[:v2_ui] = '1'; get ...; response.body.match(/<link.../)`）が `spec/requests/v2_ui_flag_spec.rb`（`v2.css` 版）と `announcements_spec.rb`（`actiontext.css` 版）の2箇所に存在する形になった。件数が増えたときは `v2_ui_flag_spec.rb` 側へ寄せる余地があるが、今回は対象コントローラーの回帰テストとしての価値もあるためこのままにした（judgement call）。

## 範囲外で気づいたこと

なし。

## Test plan

- [x] `docker compose exec app bundle exec rspec` が緑（520 examples, 0 failures, 1 pending）
- [x] `docker compose exec app bundle exec rubocop` で新規違反なし
- [x] v2 でお知らせ詳細を開くとき、レスポンスに ActionText スタイルシートへの link がある（request spec で固定）
- [x] v1 レイアウトのファイルは無変更
