### PR TITLE
test: system spec を v2 化: opt-in ヘルパーとログイン/ログアウト

### DIFF
--- a/spec/support/v2_ui_helper.rb
+++ b/spec/support/v2_ui_helper.rb
@@ -1,0 +1,11 @@
+module V2UiHelper
+  module System
+    def enable_v2_ui
+      visit root_path(v2: 1) # rubocop:disable Naming/VariableNumber
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include V2UiHelper::System, type: :system
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Logins' do
   let(:user) { create(:user) }
 
-  before { create(:record, :with_line_status, user: user) }
+  before { enable_v2_ui }
 
   it 'login with valid email and invalid password' do
     visit login_path
@@ -21,11 +21,12 @@ RSpec.describe 'Logins' do
     fill_in 'パスワード', with: user.password
     click_button 'ログインする'
     expect(page).to have_content 'ログインしました'
-    expect(page).to have_link 'プロフィール', href: user_path(user)
-    expect(page).to have_link 'ログアウト', href: logout_path
-    click_link 'ログアウト'
+    expect(page).to have_link user.name, href: user_path(user)
+    click_link user.name
+    expect(page).to have_link 'ログアウトする', href: logout_path
+    click_link 'ログアウトする'
     expect(page).to have_content 'ログアウトしました'
     expect(page).to have_link 'ログイン', href: login_path
-    expect(page).to_not have_link 'ログアウト', href: logout_path
+    expect(page).to_not have_link user.name, href: user_path(user)
   end
 end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Logins' do
     expect(page).to_not have_content 'ログインに失敗しました'
   end
 
-  it 'login with valid information followed by logout' do
+  it 'login with valid information followed by logout', :js do
     visit login_path
     fill_in 'メールアドレス', with: user.email
     fill_in 'パスワード', with: user.password
@@ -24,7 +24,7 @@ RSpec.describe 'Logins' do
     expect(page).to have_link user.name, href: user_path(user)
     click_link user.name
     expect(page).to have_link 'ログアウトする', href: logout_path
-    click_link 'ログアウトする'
+    accept_confirm { click_link 'ログアウトする' }
     expect(page).to have_content 'ログアウトしました'
     expect(page).to have_link 'ログイン', href: login_path
     expect(page).to_not have_link user.name, href: user_path(user)


### PR DESCRIPTION
## Summary

Closes #340

system spec 5 ファイルすべてが v1 前提で、v2 Cookie をセットしているものがゼロだった。塊4（#332）でフラグを反転した瞬間に一斉に落ちる状態を避けるため、v2 opt-in の方式をまず 1 つの最小ファイル（ログイン/ログアウト）で確立する。

`spec/support` に helper を 1 つ足し、`?v2=1` 付きで 1 回 visit して Cookie を立てる方式にした。`ApplicationController#handle_v2_flag` が `params[:v2] == '1'` で Cookie をセットするのは通常の HTTP レスポンスなので、rack_test（実際の HTTP レスポンスとして処理）と Selenium（実ブラウザが Set-Cookie を処理）の両方で同じコードが動く。ドライバごとに Cookie を直接セットする実装は取っていない。

`sessions_spec.rb` は v1 のヘッダー・サイドメニュー由来の文言（「プロフィール」「ログアウト」）に依存していたため、v2 の実際の UI に合わせて書き換えた。v2 のナビは `current_user.name` をプロフィールへのリンクとして出し、ログアウトはナビに置かず `users#show` にのみ配置されている（`docs/v2_ui_migration.md` の「共通ナビゲーション構造」）。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `spec/support/v2_ui_helper.rb`（新規） | `enable_v2_ui` ヘルパー。`visit root_path(v2: 1)` で v2 Cookie を立てる。`GeolocationHelper` / `LoginSupport` と同じ `System` サブモジュール + `RSpec.configure` の形 |
| `spec/system/sessions_spec.rb` | `before` で `enable_v2_ui` を呼ぶように変更。ログイン成功後のプロフィール導線を `have_link user.name, href: user_path(user)` に、ログアウトを `users#show` 側の「ログアウトする」リンクに向けて書き換え。ログアウトの `turbo_confirm` ダイアログは Selenium 上でのみ発生するため、このテストを `:js` にして `accept_confirm` で受け入れるようにした（rack_test 側のテストはもう一方の example が引き続きカバーしている） |

`before` にあった `create(:record, :with_line_status, user: user)` は削除した。理由は後述のレビュー所見を参照。

## レビュー所見

`code-review` スキルの Standards 軸 / Spec 軸を回した。どちらも CRITICAL / HIGH の指摘なし。

- Spec 軸: 元の `before` にあった `create(:record, :with_line_status, user: user)` はどの assertion にも使われておらず、かつ v2 の記録一覧（`new_records/_records_table.html+v2.erb`）が著者名を `current_user.name` と同じテキスト・同じ URL でリンクするため、ナビのプロフィールリンクと曖昧一致 (`Capybara::Ambiguous`) を起こす原因になっていた。テストを一意にするため削除した。ログイン/ログアウトの検証には無関係な fixture であることを確認済み。
- Spec 軸: 受け入れ条件の「ログアウト後、ナビにログインが出てログアウトが消える」は文字通りには実装していない。v2 のナビはそもそもログアウトリンクを持たず（ログアウトは `users#show` のみ）、ログイン前後で変わるのはプロフィールリンクの有無。実装した `expect(page).to_not have_link user.name, href: user_path(user)` は実際の v2 設計に対する正しい代替 assertion だが、チェックボックスの文言とは一致しない旨を記録しておく（judgement call）。
- Standards 軸: 指摘なし。ヘルパーの命名・構成は既存の `spec/support` の慣習（`geolocation_helper.rb` 等）に一致。

## 範囲外で気づいたこと

なし。

## Test plan

- [x] `docker compose exec app bundle exec rspec` が緑（521 examples, 0 failures, 1 pending）
- [x] `docker compose exec app bundle exec rubocop` で変更ファイルに新規違反なし（既存 117 offenses は本変更と無関係なファイルのもの）
- [x] `enable_v2_ui` が rack_test（ログイン失敗の example）と Selenium（`:js` を付けたログイン/ログアウトの example）の両方で v2 Cookie を立てられることを確認済み
- [x] v2 でログインに失敗した後、メッセージが表示され、`root_path` に遷移するとメッセージが残っていないことを確認済み
- [x] v2 でログイン成功後、ナビからプロフィール（`user.name` リンク）→ ログアウトへたどれることを確認済み
- [x] ログアウト後、ナビにログイン導線が出て、プロフィールリンクが消えていることを確認済み
